### PR TITLE
Add export/import/validate CLI to the QLaunchpad binary

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,14 +10,27 @@ let package = Package(
         .executable(name: "QLaunchpad", targets: ["QLaunchpad"])
     ],
     targets: [
+        .target(
+            name: "QLaunchpadCore",
+            path: "Sources/QLaunchpadCore"
+        ),
         .executableTarget(
             name: "QLaunchpad",
+            dependencies: ["QLaunchpadCore"],
             path: "Sources/QLaunchpad",
             resources: [
                 .process("Resources")
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)
+            ]
+        ),
+        .testTarget(
+            name: "QLaunchpadCoreTests",
+            dependencies: ["QLaunchpadCore"],
+            path: "Tests/QLaunchpadCoreTests",
+            resources: [
+                .process("Fixtures")
             ]
         )
     ]

--- a/Sources/QLaunchpad/AppDelegate.swift
+++ b/Sources/QLaunchpad/AppDelegate.swift
@@ -47,6 +47,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         buildLaunchpadPanel()
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(layoutDidChangeExternally(_:)),
+            name: .qlaunchpadLayoutDidChange,
+            object: nil
+        )
         store.load()
         installHotKey()
         applyDockIconPreference()
@@ -86,12 +92,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             self,
             selector: #selector(hotKeyRecordingChanged(_:)),
             name: .qlaunchpadHotKeyRecordingChanged,
-            object: nil
-        )
-        DistributedNotificationCenter.default().addObserver(
-            self,
-            selector: #selector(layoutDidChangeExternally(_:)),
-            name: .qlaunchpadLayoutDidChange,
             object: nil
         )
     }

--- a/Sources/QLaunchpad/AppDelegate.swift
+++ b/Sources/QLaunchpad/AppDelegate.swift
@@ -88,11 +88,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             name: .qlaunchpadHotKeyRecordingChanged,
             object: nil
         )
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(layoutDidChangeExternally(_:)),
+            name: .qlaunchpadLayoutDidChange,
+            object: nil
+        )
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         if let globalHotKeyMonitor { NSEvent.removeMonitor(globalHotKeyMonitor) }
         if let localHotKeyMonitor { NSEvent.removeMonitor(localHotKeyMonitor) }
+        DistributedNotificationCenter.default().removeObserver(
+            self,
+            name: .qlaunchpadLayoutDidChange,
+            object: nil
+        )
+    }
+
+    @objc private func layoutDidChangeExternally(_ note: Notification) {
+        let domain = note.object as? String
+        guard domain == Bundle.main.bundleIdentifier else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.store.reloadPersistedLayout()
+        }
     }
 
     /// A regular Dock application receives this callback when its Dock icon is

--- a/Sources/QLaunchpad/AppModel.swift
+++ b/Sources/QLaunchpad/AppModel.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import Foundation
+import QLaunchpadCore
 
 enum QLaunchpadPreferences {
     static let showMenuBarIconKey = "showMenuBarIcon"
@@ -129,20 +130,7 @@ enum QLaunchAppLauncher {
     }
 }
 
-/// A user-created group of applications. Folder membership is stored by the
-/// stable bundle identifier used by `AppInfo`, so rescanning applications does
-/// not invalidate folders.
-struct AppFolder: Identifiable, Hashable, Codable, Sendable {
-    let id: String
-    var name: String
-    var appIDs: [String]
-
-    init(id: String = "folder-\(UUID().uuidString)", name: String = "文件夹", appIDs: [String]) {
-        self.id = id
-        self.name = name
-        self.appIDs = appIDs
-    }
-}
+typealias AppFolder = QLaunchpadCore.AppFolder
 
 enum LaunchpadItem: Identifiable, Hashable {
     case app(AppInfo)
@@ -461,7 +449,7 @@ final class AppStore: ObservableObject {
     @Published private(set) var customApplicationSourcePaths: [String]
     @Published var showHiddenAppsInSearch: Bool {
         didSet {
-            UserDefaults.standard.set(showHiddenAppsInSearch, forKey: Self.showHiddenAppsKey)
+            UserDefaults.standard.set(showHiddenAppsInSearch, forKey: LaunchpadPersistence.showHiddenAppsKey)
             refreshFilteredApps(resetPage: true)
             NotificationCenter.default.post(name: .qlaunchpadStoreChanged, object: nil)
         }
@@ -498,22 +486,16 @@ final class AppStore: ObservableObject {
     /// Points of scroll delta that equal one full page turn.
     private let pageScrollUnit: Double = 320
 
-    private static let hiddenAppsKey = "hiddenAppIdentifiers"
-    private static let customSourcesKey = "customApplicationSourcePaths"
-    private static let showHiddenAppsKey = "showHiddenAppsInSearch"
-    private static let foldersKey = "launchpadFolders"
-    private static let itemOrderKey = "launchpadItemOrder"
-
     private var itemOrderIDs: [String]
 
     init() {
         let defaults = UserDefaults.standard
-        hiddenAppIDs = Set(defaults.stringArray(forKey: Self.hiddenAppsKey) ?? [])
-        customApplicationSourcePaths = defaults.stringArray(forKey: Self.customSourcesKey) ?? []
-        showHiddenAppsInSearch = defaults.bool(forKey: Self.showHiddenAppsKey)
-        itemOrderIDs = defaults.stringArray(forKey: Self.itemOrderKey) ?? []
-        if let data = defaults.data(forKey: Self.foldersKey),
-           let savedFolders = try? JSONDecoder().decode([AppFolder].self, from: data) {
+        hiddenAppIDs = Set(defaults.stringArray(forKey: LaunchpadPersistence.hiddenAppsKey) ?? [])
+        customApplicationSourcePaths = defaults.stringArray(forKey: LaunchpadPersistence.customSourcesKey) ?? []
+        showHiddenAppsInSearch = defaults.bool(forKey: LaunchpadPersistence.showHiddenAppsKey)
+        itemOrderIDs = defaults.stringArray(forKey: LaunchpadPersistence.itemOrderKey) ?? []
+        if let data = defaults.data(forKey: LaunchpadPersistence.foldersKey),
+           let savedFolders = try? LaunchpadPersistence.decodeFolders(data) {
             folders = savedFolders
         }
     }
@@ -1273,11 +1255,14 @@ final class AppStore: ObservableObject {
     }
 
     private func persistHiddenApps() {
-        UserDefaults.standard.set(hiddenAppIDs.sorted(), forKey: Self.hiddenAppsKey)
+        let next = hiddenAppIDs.sorted()
+        let current = UserDefaults.standard.stringArray(forKey: LaunchpadPersistence.hiddenAppsKey) ?? []
+        guard next != current else { return }
+        UserDefaults.standard.set(next, forKey: LaunchpadPersistence.hiddenAppsKey)
     }
 
     private func persistApplicationSources() {
-        UserDefaults.standard.set(customApplicationSourcePaths, forKey: Self.customSourcesKey)
+        UserDefaults.standard.set(customApplicationSourcePaths, forKey: LaunchpadPersistence.customSourcesKey)
     }
 
     private func isApp(_ item: LaunchpadItem) -> Bool {
@@ -1286,40 +1271,26 @@ final class AppStore: ObservableObject {
     }
 
     private func reconcileLaunchpadItems() {
-        let validApps = Set(apps.map(\.id)).subtracting(hiddenAppIDs)
-        var usedAppIDs = Set<String>()
-        var sanitizedFolders: [AppFolder] = []
-        for folder in folders {
-            let members = folder.appIDs.filter { validApps.contains($0) && usedAppIDs.insert($0).inserted }
-            guard !members.isEmpty else { continue }
-            var sanitized = folder
-            sanitized.appIDs = members
-            sanitizedFolders.append(sanitized)
+        let known = apps.map {
+            LaunchpadKnownApp(
+                id: $0.id,
+                bundleIdentifier: $0.bundleIdentifier,
+                name: $0.name,
+                path: $0.url.standardizedFileURL.path
+            )
         }
-        folders = sanitizedFolders
-
-        let folderByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
-        var validOrder: [String] = []
-        var seen = Set<String>()
-        for id in itemOrderIDs {
-            if let folder = folderByID[id], seen.insert(id).inserted {
-                validOrder.append(folder.id)
-            } else if validApps.contains(id), !usedAppIDs.contains(id), seen.insert(id).inserted {
-                validOrder.append(id)
-            }
-        }
-        for folder in folders where seen.insert(folder.id).inserted {
-            validOrder.append(folder.id)
-        }
-        for app in apps where validApps.contains(app.id)
-            && !usedAppIDs.contains(app.id)
-            && seen.insert(app.id).inserted {
-            validOrder.append(app.id)
-        }
-        itemOrderIDs = validOrder
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: known,
+            folders: folders,
+            order: itemOrderIDs,
+            hidden: hiddenAppIDs
+        )
+        folders = result.folders
+        itemOrderIDs = result.order
         persistFolders()
         persistItemOrder()
-        launchpadItems = validOrder.compactMap { id in
+        let folderByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
+        launchpadItems = itemOrderIDs.compactMap { id in
             if let folder = folderByID[id] { return .folder(folder) }
             guard let app = apps.first(where: { $0.id == id }) else { return nil }
             return .app(app)
@@ -1327,13 +1298,16 @@ final class AppStore: ObservableObject {
     }
 
     private func persistFolders() {
-        if let data = try? JSONEncoder().encode(folders) {
-            UserDefaults.standard.set(data, forKey: Self.foldersKey)
-        }
+        guard let data = try? LaunchpadPersistence.encodeFolders(folders) else { return }
+        let current = UserDefaults.standard.data(forKey: LaunchpadPersistence.foldersKey)
+        guard data != current else { return }
+        UserDefaults.standard.set(data, forKey: LaunchpadPersistence.foldersKey)
     }
 
     private func persistItemOrder() {
-        UserDefaults.standard.set(itemOrderIDs, forKey: Self.itemOrderKey)
+        let current = UserDefaults.standard.stringArray(forKey: LaunchpadPersistence.itemOrderKey) ?? []
+        guard itemOrderIDs != current else { return }
+        UserDefaults.standard.set(itemOrderIDs, forKey: LaunchpadPersistence.itemOrderKey)
     }
 
 }

--- a/Sources/QLaunchpad/AppModel.swift
+++ b/Sources/QLaunchpad/AppModel.swift
@@ -486,6 +486,8 @@ final class AppStore: ObservableObject {
     private var lastScrollTime: CFTimeInterval = 0
     private var scanTask: Task<Void, Never>?
     private var layoutGeneration: UInt64 = 0
+    /// Bumped by import / external reload so Metal can drop an in-flight drag.
+    private(set) var dragGeneration: UInt64 = 0
 
     /// Points of scroll delta that equal one full page turn.
     private let pageScrollUnit: Double = 320
@@ -506,6 +508,7 @@ final class AppStore: ObservableObject {
         let defaults = UserDefaults.standard
         customApplicationSourcePaths = defaults.stringArray(forKey: LaunchpadPersistence.customSourcesKey) ?? []
         showHiddenAppsInSearch = defaults.bool(forKey: LaunchpadPersistence.showHiddenAppsKey)
+        rebuildLaunchpadItems()
     }
 
     deinit {
@@ -627,13 +630,19 @@ final class AppStore: ObservableObject {
     }
 
     func exportLayout(includeCatalog: Bool = true, includePaths: Bool = true) -> LaunchpadLayoutDocument {
-        let items: [LaunchpadLayoutItem] = launchpadItems.map { item in
-            switch item {
-            case .app(let app):
-                return .app(id: app.id)
-            case .folder(let folder):
-                return .folder(id: folder.id, name: folder.name, apps: folder.appIDs)
+        let folderByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
+        var seen = Set<String>()
+        var items: [LaunchpadLayoutItem] = []
+        for id in itemOrderIDs {
+            guard seen.insert(id).inserted else { continue }
+            if let folder = folderByID[id] {
+                items.append(.folder(id: folder.id, name: folder.name, apps: folder.appIDs))
+            } else {
+                items.append(.app(id: id))
             }
+        }
+        for folder in folders where seen.insert(folder.id).inserted {
+            items.append(.folder(id: folder.id, name: folder.name, apps: folder.appIDs))
         }
         let catalog: [LaunchpadLayoutCatalogEntry]? = includeCatalog
             ? apps.map { app in
@@ -665,6 +674,9 @@ final class AppStore: ObservableObject {
         _ document: LaunchpadLayoutDocument,
         mode: LaunchpadLayoutImportMode
     ) throws -> LaunchpadLayoutReport {
+        guard !isLoading, !apps.isEmpty else {
+            throw LaunchpadLayoutError.malformed("application catalog is empty")
+        }
         let (applied, report) = try LaunchpadLayoutImporter.apply(
             document: document,
             mode: mode,
@@ -702,7 +714,11 @@ final class AppStore: ObservableObject {
     func reloadPersistedLayout() {
         layoutGeneration += 1
         adoptPersistedLayout()
-        reconcileLaunchpadItems()
+        if apps.isEmpty {
+            rebuildLaunchpadItems()
+        } else {
+            reconcileLaunchpadItems(persist: false)
+        }
         cancelActiveDrag()
         if let openedFolderID, folder(withID: openedFolderID) == nil {
             exitFolder()
@@ -1400,9 +1416,10 @@ final class AppStore: ObservableObject {
     private func cancelActiveDrag() {
         isDraggingFolderApp = false
         isFolderRemovalTargeted = false
+        dragGeneration += 1
     }
 
-    private func reconcileLaunchpadItems() {
+    private func reconcileLaunchpadItems(persist: Bool = true) {
         let result = LaunchpadLayoutReconciler.reconcile(
             apps: knownApps(),
             folders: folders,
@@ -1411,7 +1428,9 @@ final class AppStore: ObservableObject {
         )
         folders = result.folders
         itemOrderIDs = result.order
-        persistLayout()
+        if persist {
+            persistLayout()
+        }
         rebuildLaunchpadItems()
     }
 
@@ -1425,6 +1444,9 @@ final class AppStore: ObservableObject {
     }
 
     private func persistLayout() {
+        // An empty catalog is the first-scan window, not a real layout. Persisting
+        // a reconcile of `apps = []` would write an empty grid over a live import.
+        guard !apps.isEmpty else { return }
         guard let foldersData = try? LaunchpadPreferenceStore.encodeFolders(folders) else { return }
         LaunchpadPreferenceStore.writeLayout(
             domain: Self.preferenceDomain,

--- a/Sources/QLaunchpad/AppModel.swift
+++ b/Sources/QLaunchpad/AppModel.swift
@@ -1,7 +1,10 @@
 import AppKit
 import Combine
 import Foundation
+import os
 import QLaunchpadCore
+
+private let layoutLogger = Logger(subsystem: "com.qzrzz.qlaunchpad", category: "layout")
 
 enum QLaunchpadPreferences {
     static let showMenuBarIconKey = "showMenuBarIcon"
@@ -482,22 +485,27 @@ final class AppStore: ObservableObject {
     private var scrollAccumulated: Double = 0
     private var lastScrollTime: CFTimeInterval = 0
     private var scanTask: Task<Void, Never>?
+    private var layoutGeneration: UInt64 = 0
 
     /// Points of scroll delta that equal one full page turn.
     private let pageScrollUnit: Double = 320
 
     private var itemOrderIDs: [String]
 
+    private static var preferenceDomain: String {
+        Bundle.main.bundleIdentifier ?? (kCFPreferencesCurrentApplication as String)
+    }
+
     init() {
+        let layout = LaunchpadPreferenceStore.readLayout(domain: Self.preferenceDomain)
+        LaunchpadPreferenceStore.writeThroughToStandardDefaults(layout)
+        hiddenAppIDs = Set(layout.hiddenIDs)
+        itemOrderIDs = layout.itemOrder
+        folders = (try? LaunchpadPreferenceStore.decodeFolders(layout.foldersData)) ?? []
+
         let defaults = UserDefaults.standard
-        hiddenAppIDs = Set(defaults.stringArray(forKey: LaunchpadPersistence.hiddenAppsKey) ?? [])
         customApplicationSourcePaths = defaults.stringArray(forKey: LaunchpadPersistence.customSourcesKey) ?? []
         showHiddenAppsInSearch = defaults.bool(forKey: LaunchpadPersistence.showHiddenAppsKey)
-        itemOrderIDs = defaults.stringArray(forKey: LaunchpadPersistence.itemOrderKey) ?? []
-        if let data = defaults.data(forKey: LaunchpadPersistence.foldersKey),
-           let savedFolders = try? LaunchpadPersistence.decodeFolders(data) {
-            folders = savedFolders
-        }
     }
 
     deinit {
@@ -590,10 +598,12 @@ final class AppStore: ObservableObject {
     func load() {
         // A detached scan cannot be stopped reliably once it has started.
         // Ignore duplicate requests instead of allowing two filesystem scans
-        // to run at the same time.
+        // to run at the same time. Import / external reload must not cancel
+        // or nil this task — they only bump `layoutGeneration`.
         guard scanTask == nil else { return }
 
         isLoading = true
+        let generationAtStart = layoutGeneration
         let additionalRoots = customApplicationSourcePaths.map { URL(fileURLWithPath: $0) }
         scanTask = Task { @MainActor [weak self] in
             let result = await Task.detached(priority: .userInitiated) {
@@ -601,6 +611,10 @@ final class AppStore: ObservableObject {
             }.value
             guard let self else { return }
             apps = result
+            if layoutGeneration != generationAtStart {
+                layoutLogger.debug("layout.scan.generationAdvanced readLayout=true")
+                adoptPersistedLayout()
+            }
             reconcileLaunchpadItems()
             // A scan also runs when the Launchpad is shown again. Keep the
             // current page while refreshing the catalog; the non-reset path
@@ -610,6 +624,92 @@ final class AppStore: ObservableObject {
             scanTask = nil
             NotificationCenter.default.post(name: .qlaunchpadStoreChanged, object: nil)
         }
+    }
+
+    func exportLayout(includeCatalog: Bool = true, includePaths: Bool = true) -> LaunchpadLayoutDocument {
+        let items: [LaunchpadLayoutItem] = launchpadItems.map { item in
+            switch item {
+            case .app(let app):
+                return .app(id: app.id)
+            case .folder(let folder):
+                return .folder(id: folder.id, name: folder.name, apps: folder.appIDs)
+            }
+        }
+        let catalog: [LaunchpadLayoutCatalogEntry]? = includeCatalog
+            ? apps.map { app in
+                LaunchpadLayoutCatalogEntry(
+                    id: app.id,
+                    bundleIdentifier: app.bundleIdentifier,
+                    name: app.name,
+                    path: includePaths ? app.url.standardizedFileURL.path : nil
+                )
+            }
+            : nil
+        let preset = GridLayoutPreset.current
+        return LaunchpadLayoutDocument(
+            exportedAt: Date(),
+            appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            grid: LaunchpadLayoutGrid(
+                preset: preset.rawValue,
+                columns: preset.columns,
+                rows: preset.rows,
+                pageCapacity: preset.columns * preset.rows
+            ),
+            items: items,
+            hidden: hiddenAppIDs.sorted(),
+            catalog: catalog
+        )
+    }
+
+    func applyLayout(
+        _ document: LaunchpadLayoutDocument,
+        mode: LaunchpadLayoutImportMode
+    ) throws -> LaunchpadLayoutReport {
+        let (applied, report) = try LaunchpadLayoutImporter.apply(
+            document: document,
+            mode: mode,
+            strict: false,
+            scanned: knownApps(),
+            currentHidden: hiddenAppIDs
+        )
+        writeLayoutBackupFailOpen()
+        let foldersData = try LaunchpadPreferenceStore.encodeFolders(applied.folders)
+        LaunchpadPreferenceStore.writeLayout(
+            domain: Self.preferenceDomain,
+            LaunchpadPersistedLayout(
+                itemOrder: applied.order,
+                foldersData: foldersData,
+                hiddenIDs: Array(applied.hidden)
+            )
+        )
+        folders = applied.folders
+        itemOrderIDs = applied.order
+        hiddenAppIDs = applied.hidden
+        rebuildLaunchpadItems()
+        cancelActiveDrag()
+        layoutGeneration += 1
+        if let openedFolderID, folder(withID: openedFolderID) == nil {
+            exitFolder()
+        }
+        refreshFilteredApps(resetPage: false)
+        layoutLogger.info(
+            "layout.import imported=\(report.importedRootItems) folders=\(report.importedFolders) skipped=\(report.skippedUnknown.count)"
+        )
+        NotificationCenter.default.post(name: .qlaunchpadStoreChanged, object: nil)
+        return report
+    }
+
+    func reloadPersistedLayout() {
+        layoutGeneration += 1
+        adoptPersistedLayout()
+        reconcileLaunchpadItems()
+        cancelActiveDrag()
+        if let openedFolderID, folder(withID: openedFolderID) == nil {
+            exitFolder()
+        }
+        refreshFilteredApps(resetPage: false)
+        layoutLogger.info("layout.reload from distributed notification")
+        NotificationCenter.default.post(name: .qlaunchpadStoreChanged, object: nil)
     }
 
     func updateSearch(_ text: String) {
@@ -1255,10 +1355,7 @@ final class AppStore: ObservableObject {
     }
 
     private func persistHiddenApps() {
-        let next = hiddenAppIDs.sorted()
-        let current = UserDefaults.standard.stringArray(forKey: LaunchpadPersistence.hiddenAppsKey) ?? []
-        guard next != current else { return }
-        UserDefaults.standard.set(next, forKey: LaunchpadPersistence.hiddenAppsKey)
+        persistLayout()
     }
 
     private func persistApplicationSources() {
@@ -1270,8 +1367,8 @@ final class AppStore: ObservableObject {
         return false
     }
 
-    private func reconcileLaunchpadItems() {
-        let known = apps.map {
+    private func knownApps() -> [LaunchpadKnownApp] {
+        apps.map {
             LaunchpadKnownApp(
                 id: $0.id,
                 bundleIdentifier: $0.bundleIdentifier,
@@ -1279,16 +1376,46 @@ final class AppStore: ObservableObject {
                 path: $0.url.standardizedFileURL.path
             )
         }
+    }
+
+    private func adoptPersistedLayout() {
+        let layout = LaunchpadPreferenceStore.readLayout(domain: Self.preferenceDomain)
+        LaunchpadPreferenceStore.writeThroughToStandardDefaults(layout)
+        itemOrderIDs = layout.itemOrder
+        hiddenAppIDs = Set(layout.hiddenIDs)
+        folders = (try? LaunchpadPreferenceStore.decodeFolders(layout.foldersData)) ?? []
+    }
+
+    private func writeLayoutBackupFailOpen() {
+        do {
+            try LaunchpadPreferenceStore.writeLayoutBackup(
+                domain: Self.preferenceDomain,
+                document: exportLayout(includeCatalog: true, includePaths: true)
+            )
+        } catch {
+            layoutLogger.warning("layout.backup.failed \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func cancelActiveDrag() {
+        isDraggingFolderApp = false
+        isFolderRemovalTargeted = false
+    }
+
+    private func reconcileLaunchpadItems() {
         let result = LaunchpadLayoutReconciler.reconcile(
-            apps: known,
+            apps: knownApps(),
             folders: folders,
             order: itemOrderIDs,
             hidden: hiddenAppIDs
         )
         folders = result.folders
         itemOrderIDs = result.order
-        persistFolders()
-        persistItemOrder()
+        persistLayout()
+        rebuildLaunchpadItems()
+    }
+
+    private func rebuildLaunchpadItems() {
         let folderByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
         launchpadItems = itemOrderIDs.compactMap { id in
             if let folder = folderByID[id] { return .folder(folder) }
@@ -1297,17 +1424,24 @@ final class AppStore: ObservableObject {
         }
     }
 
+    private func persistLayout() {
+        guard let foldersData = try? LaunchpadPreferenceStore.encodeFolders(folders) else { return }
+        LaunchpadPreferenceStore.writeLayout(
+            domain: Self.preferenceDomain,
+            LaunchpadPersistedLayout(
+                itemOrder: itemOrderIDs,
+                foldersData: foldersData,
+                hiddenIDs: hiddenAppIDs.sorted()
+            )
+        )
+    }
+
     private func persistFolders() {
-        guard let data = try? LaunchpadPersistence.encodeFolders(folders) else { return }
-        let current = UserDefaults.standard.data(forKey: LaunchpadPersistence.foldersKey)
-        guard data != current else { return }
-        UserDefaults.standard.set(data, forKey: LaunchpadPersistence.foldersKey)
+        persistLayout()
     }
 
     private func persistItemOrder() {
-        let current = UserDefaults.standard.stringArray(forKey: LaunchpadPersistence.itemOrderKey) ?? []
-        guard itemOrderIDs != current else { return }
-        UserDefaults.standard.set(itemOrderIDs, forKey: LaunchpadPersistence.itemOrderKey)
+        persistLayout()
     }
 
 }

--- a/Sources/QLaunchpad/GridLayout.swift
+++ b/Sources/QLaunchpad/GridLayout.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import QLaunchpadCore
 
 /// Layout metrics for a Launchpad-style icon grid.
 /// Icon texture pixel size is `iconPointSize * IconRenderQuality.current.rasterScale`
@@ -10,7 +11,7 @@ enum GridLayoutPreset: String, CaseIterable, Identifiable {
     case sixByFour = "6x4-128"
     case sevenByFive = "7x5-128"
 
-    static let defaultsKey = "gridLayoutPreset"
+    static let defaultsKey = LaunchpadPersistence.gridLayoutPresetKey
     static let defaultPreset: Self = .sixByFour
 
     var id: Self { self }

--- a/Sources/QLaunchpad/LaunchpadCLI.swift
+++ b/Sources/QLaunchpad/LaunchpadCLI.swift
@@ -3,17 +3,8 @@ import Foundation
 import QLaunchpadCore
 
 enum LaunchpadCLI {
-    private static let knownDomains: Set<String> = [
-        LaunchpadPreferenceStore.releaseDomain,
-        LaunchpadPreferenceStore.developmentDomain
-    ]
-
     static func isInvocation(_ args: [String]) -> Bool {
-        guard let first = args.first else { return false }
-        if Self.commands.contains(first) || first == "help" || first == "-h" || first == "--help" {
-            return true
-        }
-        return args.contains("--cli")
+        LaunchpadCLIInvocation.isInvocation(args)
     }
 
     static func run(_ args: [String]) -> Int32 {
@@ -28,6 +19,10 @@ enum LaunchpadCLI {
         } catch let error as LaunchpadLayoutError {
             fputs("error: \(describe(error))\n", stderr)
             return 2
+        } catch let error as LaunchpadCLIInvocation.ParseError {
+            fputs("error: \(error.message)\n", stderr)
+            fputs(usageText, stderr)
+            return 1
         } catch let error as DecodingError {
             fputs("error: invalid layout JSON: \(error)\n", stderr)
             return 2
@@ -37,22 +32,8 @@ enum LaunchpadCLI {
         }
     }
 
-    private static let commands: Set<String> = ["export", "import", "validate"]
-
     private static func execute(_ rawArgs: [String]) throws -> Int32 {
-        let args = rawArgs.filter { $0 != "--cli" }
-        guard let command = args.first else {
-            throw CLIError.usage("missing command")
-        }
-        if command == "help" || command == "-h" || command == "--help" {
-            fputs(usageText, stdout)
-            return 0
-        }
-        guard commands.contains(command) else {
-            throw CLIError.usage("unknown command '\(command)'")
-        }
-
-        let options = try parseOptions(Array(args.dropFirst()), command: command)
+        let (command, options) = try LaunchpadCLIInvocation.parse(rawArgs)
         if options.help {
             fputs(usageText, stdout)
             return 0
@@ -70,12 +51,12 @@ enum LaunchpadCLI {
         }
     }
 
-    private static func runExport(_ options: Options) throws -> Int32 {
+    private static func runExport(_ options: LaunchpadCLIInvocation.Options) throws -> Int32 {
         let domain = try resolveDomain(options)
         fputs("usingDomain: \(domain)\n", stderr)
         try ensureDomainAvailable(domain)
 
-        let snapshot = scanAndReconcile(domain: domain)
+        let snapshot = try scanAndReconcile(domain: domain, failOnCorruptFolders: false)
         let document = makeDocument(
             snapshot,
             grid: gridSnapshot(domain: domain),
@@ -83,13 +64,18 @@ enum LaunchpadCLI {
             includePaths: options.includePaths,
             appVersion: appVersion(options)
         )
-        let pretty = try shouldPretty(options, writingToStdout: isStandardStream(options.out))
+        let pretty = try LaunchpadCLIInvocation.shouldPretty(
+            pretty: options.pretty,
+            compact: options.compact,
+            writingToStdout: isStandardStream(options.out),
+            stdoutIsTTY: isatty(STDOUT_FILENO) != 0
+        )
         let data = try LaunchpadLayoutDocument.makeEncoder(pretty: pretty).encode(document)
         try writeOutput(data, to: options.out)
         return 0
     }
 
-    private static func runImport(_ options: Options) throws -> Int32 {
+    private static func runImport(_ options: LaunchpadCLIInvocation.Options) throws -> Int32 {
         if options.merge && options.replace {
             throw CLIError.usage("--merge and --replace are mutually exclusive")
         }
@@ -103,8 +89,9 @@ enum LaunchpadCLI {
             LaunchpadLayoutDocument.self,
             from: data
         )
+        try LaunchpadLayoutImporter.validate(document)
 
-        let snapshot = scanAndReconcile(domain: domain)
+        let snapshot = try scanAndReconcile(domain: domain, failOnCorruptFolders: true)
         if snapshot.apps.isEmpty {
             throw CLIError.validate("application catalog is empty")
         }
@@ -125,7 +112,7 @@ enum LaunchpadCLI {
 
         writeBackupFailOpen(domain: domain, snapshot: snapshot, appVersion: appVersion(options))
         let foldersData = try LaunchpadPreferenceStore.encodeFolders(applied.folders)
-        LaunchpadPreferenceStore.writeLayout(
+        let wrote = LaunchpadPreferenceStore.writeLayout(
             domain: domain,
             LaunchpadPersistedLayout(
                 itemOrder: applied.order,
@@ -133,6 +120,9 @@ enum LaunchpadCLI {
                 hiddenIDs: Array(applied.hidden)
             )
         )
+        guard wrote else {
+            throw CLIError.prefsUnavailable("failed to persist layout to \(domain)")
+        }
         DistributedNotificationCenter.default().postNotificationName(
             .qlaunchpadLayoutDidChange,
             object: domain,
@@ -143,7 +133,7 @@ enum LaunchpadCLI {
         return 0
     }
 
-    private static func runValidate(_ options: Options) throws -> Int32 {
+    private static func runValidate(_ options: LaunchpadCLIInvocation.Options) throws -> Int32 {
         let data = try readInput(options.input)
         try LaunchpadLayoutImporter.validateJSONSize(data)
         let document = try LaunchpadLayoutDocument.makeDecoder().decode(
@@ -156,22 +146,18 @@ enum LaunchpadCLI {
 
     // MARK: - Domain
 
-    private static func resolveDomain(_ options: Options) throws -> String {
-        if let domain = options.domain?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !domain.isEmpty {
-            return domain
+    private static func resolveDomain(_ options: LaunchpadCLIInvocation.Options) throws -> String {
+        let appIdentifier: String?
+        if options.domain == nil, let appPath = options.app {
+            appIdentifier = try bundleIdentifier(fromAppPath: appPath)
+        } else {
+            appIdentifier = nil
         }
-        if let appPath = options.app {
-            return try bundleIdentifier(fromAppPath: appPath)
-        }
-        if options.dev {
-            return LaunchpadPreferenceStore.developmentDomain
-        }
-        if let identifier = Bundle.main.bundleIdentifier, knownDomains.contains(identifier) {
-            return identifier
-        }
-        throw CLIError.usage(
-            "preference domain is required when not running from a packaged QLaunch.app / QLaunch Dev.app; use --domain, --dev, or --app"
+        return try LaunchpadCLIInvocation.resolveDomain(
+            explicitDomain: options.domain,
+            appIdentifier: appIdentifier,
+            dev: options.dev,
+            bundledIdentifier: Bundle.main.bundleIdentifier
         )
     }
 
@@ -222,7 +208,7 @@ enum LaunchpadCLI {
         var hidden: Set<String>
     }
 
-    private static func scanAndReconcile(domain: String) -> Snapshot {
+    private static func scanAndReconcile(domain: String, failOnCorruptFolders: Bool) throws -> Snapshot {
         let extraRoots = LaunchpadPreferenceStore.readStringArray(
             domain: domain,
             key: LaunchpadPersistence.customSourcesKey
@@ -236,7 +222,19 @@ enum LaunchpadCLI {
             )
         }
         let persisted = LaunchpadPreferenceStore.readLayout(domain: domain)
-        let folders = (try? LaunchpadPreferenceStore.decodeFolders(persisted.foldersData)) ?? []
+        let folders: [AppFolder]
+        do {
+            folders = try LaunchpadPreferenceStore.decodePersistedFolders(persisted.foldersData)
+        } catch {
+            if failOnCorruptFolders {
+                throw CLIError.validate("corrupt launchpadFolders data: \(error.localizedDescription)")
+            }
+            fputs(
+                "warning: corrupt launchpadFolders data; exporting without folders: \(error.localizedDescription)\n",
+                stderr
+            )
+            folders = []
+        }
         let hidden = Set(persisted.hiddenIDs)
         let reconciled = LaunchpadLayoutReconciler.reconcile(
             apps: known,
@@ -285,7 +283,7 @@ enum LaunchpadCLI {
             guard seen.insert(id).inserted else { continue }
             if let folder = folderByID[id] {
                 items.append(.folder(id: folder.id, name: folder.name, apps: folder.appIDs))
-            } else {
+            } else if snapshot.apps.contains(where: { $0.id == id }) {
                 items.append(.app(id: id))
             }
         }
@@ -312,7 +310,7 @@ enum LaunchpadCLI {
         )
     }
 
-    private static func appVersion(_ options: Options) -> String? {
+    private static func appVersion(_ options: LaunchpadCLIInvocation.Options) -> String? {
         if let appPath = options.app {
             let url = appBundleURL(from: URL(fileURLWithPath: (appPath as NSString).expandingTildeInPath))
             if let bundle = Bundle(url: url),
@@ -377,18 +375,6 @@ enum LaunchpadCLI {
         path == nil || path == "-"
     }
 
-    private static func shouldPretty(_ options: Options, writingToStdout: Bool) throws -> Bool {
-        if options.pretty && options.compact {
-            throw CLIError.usage("--pretty and --compact are mutually exclusive")
-        }
-        if options.pretty { return true }
-        if options.compact { return false }
-        if writingToStdout {
-            return isatty(STDOUT_FILENO) != 0
-        }
-        return true
-    }
-
     private static func printReport(_ report: LaunchpadLayoutReport, wouldWriteDomain: String?) {
         let rootApps = max(0, report.importedRootItems - report.importedFolders)
         let referenced = report.resolvedApps + report.skippedUnknown.count
@@ -412,133 +398,6 @@ enum LaunchpadCLI {
 
     private static func formatList(_ ids: [String]) -> String {
         ids.isEmpty ? "(none)" : ids.joined(separator: ", ")
-    }
-
-    // MARK: - Args
-
-    private struct Options {
-        var out: String?
-        var input: String?
-        var pretty = false
-        var compact = false
-        var includeCatalog = true
-        var includePaths = true
-        var domain: String?
-        var app: String?
-        var dev = false
-        var merge = false
-        var replace = false
-        var strict = false
-        var dryRun = false
-        var help = false
-    }
-
-    private static func parseOptions(_ args: [String], command: String) throws -> Options {
-        var options = Options()
-        var index = 0
-        while index < args.count {
-            let arg = args[index]
-            if arg == "-h" || arg == "--help" {
-                options.help = true
-                index += 1
-                continue
-            }
-            switch arg {
-            case "--out":
-                options.out = try takeValue(arg, args: args, index: &index)
-            case "--in":
-                options.input = try takeValue(arg, args: args, index: &index)
-            case "--domain":
-                options.domain = try takeValue(arg, args: args, index: &index)
-            case "--app":
-                options.app = try takeValue(arg, args: args, index: &index)
-            case "--pretty":
-                options.pretty = true
-                index += 1
-            case "--compact":
-                options.compact = true
-                index += 1
-            case "--no-catalog":
-                options.includeCatalog = false
-                index += 1
-            case "--no-paths":
-                options.includePaths = false
-                index += 1
-            case "--dev":
-                options.dev = true
-                index += 1
-            case "--merge":
-                options.merge = true
-                index += 1
-            case "--replace":
-                options.replace = true
-                index += 1
-            case "--strict":
-                options.strict = true
-                index += 1
-            case "--dry-run":
-                options.dryRun = true
-                index += 1
-            default:
-                if arg.hasPrefix("--out=") {
-                    options.out = String(arg.dropFirst("--out=".count))
-                    index += 1
-                } else if arg.hasPrefix("--in=") {
-                    options.input = String(arg.dropFirst("--in=".count))
-                    index += 1
-                } else if arg.hasPrefix("--domain=") {
-                    options.domain = String(arg.dropFirst("--domain=".count))
-                    index += 1
-                } else if arg.hasPrefix("--app=") {
-                    options.app = String(arg.dropFirst("--app=".count))
-                    index += 1
-                } else {
-                    throw CLIError.usage("unexpected argument '\(arg)'")
-                }
-            }
-        }
-
-        switch command {
-        case "export":
-            if options.input != nil || options.merge || options.replace || options.strict || options.dryRun {
-                throw CLIError.usage("export does not accept --in / --merge / --replace / --strict / --dry-run")
-            }
-        case "import":
-            if options.out != nil || options.pretty || options.compact
-                || !options.includeCatalog || !options.includePaths {
-                throw CLIError.usage("import does not accept --out / --pretty / --compact / --no-catalog / --no-paths")
-            }
-        case "validate":
-            if options.out != nil || options.pretty || options.compact
-                || !options.includeCatalog || !options.includePaths
-                || options.domain != nil || options.app != nil || options.dev
-                || options.merge || options.replace || options.strict || options.dryRun {
-                throw CLIError.usage("validate only accepts --in")
-            }
-        default:
-            break
-        }
-
-        if options.pretty && options.compact {
-            throw CLIError.usage("--pretty and --compact are mutually exclusive")
-        }
-        if options.merge && options.replace {
-            throw CLIError.usage("--merge and --replace are mutually exclusive")
-        }
-        return options
-    }
-
-    private static func takeValue(_ flag: String, args: [String], index: inout Int) throws -> String {
-        let next = index + 1
-        guard next < args.count else {
-            throw CLIError.usage("\(flag) requires a value")
-        }
-        let value = args[next]
-        if value.hasPrefix("--") && value != "-" {
-            throw CLIError.usage("\(flag) requires a value")
-        }
-        index = next + 1
-        return value
     }
 
     private static func describe(_ error: LaunchpadLayoutError) -> String {

--- a/Sources/QLaunchpad/LaunchpadCLI.swift
+++ b/Sources/QLaunchpad/LaunchpadCLI.swift
@@ -1,0 +1,602 @@
+import Darwin
+import Foundation
+import QLaunchpadCore
+
+enum LaunchpadCLI {
+    private static let knownDomains: Set<String> = [
+        LaunchpadPreferenceStore.releaseDomain,
+        LaunchpadPreferenceStore.developmentDomain
+    ]
+
+    static func isInvocation(_ args: [String]) -> Bool {
+        guard let first = args.first else { return false }
+        if Self.commands.contains(first) || first == "help" || first == "-h" || first == "--help" {
+            return true
+        }
+        return args.contains("--cli")
+    }
+
+    static func run(_ args: [String]) -> Int32 {
+        do {
+            return try execute(args)
+        } catch let error as CLIError {
+            fputs("error: \(error.message)\n", stderr)
+            if case .usage = error {
+                fputs(usageText, stderr)
+            }
+            return error.exitCode
+        } catch let error as LaunchpadLayoutError {
+            fputs("error: \(describe(error))\n", stderr)
+            return 2
+        } catch let error as DecodingError {
+            fputs("error: invalid layout JSON: \(error)\n", stderr)
+            return 2
+        } catch {
+            fputs("error: \(error.localizedDescription)\n", stderr)
+            return 3
+        }
+    }
+
+    private static let commands: Set<String> = ["export", "import", "validate"]
+
+    private static func execute(_ rawArgs: [String]) throws -> Int32 {
+        let args = rawArgs.filter { $0 != "--cli" }
+        guard let command = args.first else {
+            throw CLIError.usage("missing command")
+        }
+        if command == "help" || command == "-h" || command == "--help" {
+            fputs(usageText, stdout)
+            return 0
+        }
+        guard commands.contains(command) else {
+            throw CLIError.usage("unknown command '\(command)'")
+        }
+
+        let options = try parseOptions(Array(args.dropFirst()), command: command)
+        if options.help {
+            fputs(usageText, stdout)
+            return 0
+        }
+
+        switch command {
+        case "export":
+            return try runExport(options)
+        case "import":
+            return try runImport(options)
+        case "validate":
+            return try runValidate(options)
+        default:
+            throw CLIError.usage("unknown command '\(command)'")
+        }
+    }
+
+    private static func runExport(_ options: Options) throws -> Int32 {
+        let domain = try resolveDomain(options)
+        fputs("usingDomain: \(domain)\n", stderr)
+        try ensureDomainAvailable(domain)
+
+        let snapshot = scanAndReconcile(domain: domain)
+        let document = makeDocument(
+            snapshot,
+            grid: gridSnapshot(domain: domain),
+            includeCatalog: options.includeCatalog,
+            includePaths: options.includePaths,
+            appVersion: appVersion(options)
+        )
+        let pretty = try shouldPretty(options, writingToStdout: isStandardStream(options.out))
+        let data = try LaunchpadLayoutDocument.makeEncoder(pretty: pretty).encode(document)
+        try writeOutput(data, to: options.out)
+        return 0
+    }
+
+    private static func runImport(_ options: Options) throws -> Int32 {
+        if options.merge && options.replace {
+            throw CLIError.usage("--merge and --replace are mutually exclusive")
+        }
+        let domain = try resolveDomain(options)
+        fputs("usingDomain: \(domain)\n", stderr)
+        try ensureDomainAvailable(domain)
+
+        let data = try readInput(options.input)
+        try LaunchpadLayoutImporter.validateJSONSize(data)
+        let document = try LaunchpadLayoutDocument.makeDecoder().decode(
+            LaunchpadLayoutDocument.self,
+            from: data
+        )
+
+        let snapshot = scanAndReconcile(domain: domain)
+        if snapshot.apps.isEmpty {
+            throw CLIError.validate("application catalog is empty")
+        }
+
+        let mode: LaunchpadLayoutImportMode = options.replace ? .replace : .merge
+        let (applied, report) = try LaunchpadLayoutImporter.apply(
+            document: document,
+            mode: mode,
+            strict: options.strict,
+            scanned: snapshot.apps,
+            currentHidden: snapshot.hidden
+        )
+
+        if options.dryRun {
+            printReport(report, wouldWriteDomain: domain)
+            return 0
+        }
+
+        writeBackupFailOpen(domain: domain, snapshot: snapshot, appVersion: appVersion(options))
+        let foldersData = try LaunchpadPreferenceStore.encodeFolders(applied.folders)
+        LaunchpadPreferenceStore.writeLayout(
+            domain: domain,
+            LaunchpadPersistedLayout(
+                itemOrder: applied.order,
+                foldersData: foldersData,
+                hiddenIDs: Array(applied.hidden)
+            )
+        )
+        DistributedNotificationCenter.default().postNotificationName(
+            .qlaunchpadLayoutDidChange,
+            object: domain,
+            userInfo: ["source": "cli", "schemaVersion": 1],
+            deliverImmediately: true
+        )
+        printReport(report, wouldWriteDomain: nil)
+        return 0
+    }
+
+    private static func runValidate(_ options: Options) throws -> Int32 {
+        let data = try readInput(options.input)
+        try LaunchpadLayoutImporter.validateJSONSize(data)
+        let document = try LaunchpadLayoutDocument.makeDecoder().decode(
+            LaunchpadLayoutDocument.self,
+            from: data
+        )
+        try LaunchpadLayoutImporter.validate(document)
+        return 0
+    }
+
+    // MARK: - Domain
+
+    private static func resolveDomain(_ options: Options) throws -> String {
+        if let domain = options.domain?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !domain.isEmpty {
+            return domain
+        }
+        if let appPath = options.app {
+            return try bundleIdentifier(fromAppPath: appPath)
+        }
+        if options.dev {
+            return LaunchpadPreferenceStore.developmentDomain
+        }
+        if let identifier = Bundle.main.bundleIdentifier, knownDomains.contains(identifier) {
+            return identifier
+        }
+        throw CLIError.usage(
+            "preference domain is required when not running from a packaged QLaunch.app / QLaunch Dev.app; use --domain, --dev, or --app"
+        )
+    }
+
+    private static func bundleIdentifier(fromAppPath path: String) throws -> String {
+        let expanded = (path as NSString).expandingTildeInPath
+        guard FileManager.default.fileExists(atPath: expanded) else {
+            throw CLIError.io("app bundle not found: \(path)")
+        }
+        let url = appBundleURL(from: URL(fileURLWithPath: expanded))
+        guard let bundle = Bundle(url: url),
+              let identifier = bundle.bundleIdentifier,
+              !identifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw CLIError.prefsUnavailable("could not read CFBundleIdentifier from \(url.path)")
+        }
+        return identifier
+    }
+
+    private static func appBundleURL(from url: URL) -> URL {
+        if url.pathExtension == "app" {
+            return url
+        }
+        var current = url
+        for _ in 0..<6 {
+            if current.pathExtension == "app" {
+                return current
+            }
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                break
+            }
+            current = parent
+        }
+        return url
+    }
+
+    private static func ensureDomainAvailable(_ domain: String) throws {
+        if !CFPreferencesAppSynchronize(domain as CFString) {
+            throw CLIError.prefsUnavailable("preference domain unavailable: \(domain)")
+        }
+    }
+
+    // MARK: - Scan / document
+
+    private struct Snapshot {
+        var apps: [LaunchpadKnownApp]
+        var folders: [AppFolder]
+        var order: [String]
+        var hidden: Set<String>
+    }
+
+    private static func scanAndReconcile(domain: String) -> Snapshot {
+        let extraRoots = LaunchpadPreferenceStore.readStringArray(
+            domain: domain,
+            key: LaunchpadPersistence.customSourcesKey
+        ).map { URL(fileURLWithPath: $0) }
+        let known = AppScanner.scan(additionalRoots: extraRoots).map { app in
+            LaunchpadKnownApp(
+                id: app.id,
+                bundleIdentifier: app.bundleIdentifier,
+                name: app.name,
+                path: app.url.standardizedFileURL.path
+            )
+        }
+        let persisted = LaunchpadPreferenceStore.readLayout(domain: domain)
+        let folders = (try? LaunchpadPreferenceStore.decodeFolders(persisted.foldersData)) ?? []
+        let hidden = Set(persisted.hiddenIDs)
+        let reconciled = LaunchpadLayoutReconciler.reconcile(
+            apps: known,
+            folders: folders,
+            order: persisted.itemOrder,
+            hidden: hidden
+        )
+        return Snapshot(
+            apps: known,
+            folders: reconciled.folders,
+            order: reconciled.order,
+            hidden: hidden
+        )
+    }
+
+    private static func gridSnapshot(domain: String) -> LaunchpadLayoutGrid {
+        let raw = LaunchpadPreferenceStore.readString(
+            domain: domain,
+            key: LaunchpadPersistence.gridLayoutPresetKey
+        )
+        let preset: GridLayoutPreset
+        if let rawValue = raw, let parsed = GridLayoutPreset(rawValue: rawValue) {
+            preset = parsed
+        } else {
+            preset = .defaultPreset
+        }
+        return LaunchpadLayoutGrid(
+            preset: preset.rawValue,
+            columns: preset.columns,
+            rows: preset.rows,
+            pageCapacity: preset.columns * preset.rows
+        )
+    }
+
+    private static func makeDocument(
+        _ snapshot: Snapshot,
+        grid: LaunchpadLayoutGrid,
+        includeCatalog: Bool,
+        includePaths: Bool,
+        appVersion: String?
+    ) -> LaunchpadLayoutDocument {
+        let folderByID = Dictionary(uniqueKeysWithValues: snapshot.folders.map { ($0.id, $0) })
+        var seen = Set<String>()
+        var items: [LaunchpadLayoutItem] = []
+        for id in snapshot.order {
+            guard seen.insert(id).inserted else { continue }
+            if let folder = folderByID[id] {
+                items.append(.folder(id: folder.id, name: folder.name, apps: folder.appIDs))
+            } else {
+                items.append(.app(id: id))
+            }
+        }
+        for folder in snapshot.folders where seen.insert(folder.id).inserted {
+            items.append(.folder(id: folder.id, name: folder.name, apps: folder.appIDs))
+        }
+        let catalog: [LaunchpadLayoutCatalogEntry]? = includeCatalog
+            ? snapshot.apps.map { app in
+                LaunchpadLayoutCatalogEntry(
+                    id: app.id,
+                    bundleIdentifier: app.bundleIdentifier,
+                    name: app.name,
+                    path: includePaths ? app.path : nil
+                )
+            }
+            : nil
+        return LaunchpadLayoutDocument(
+            exportedAt: Date(),
+            appVersion: appVersion,
+            grid: grid,
+            items: items,
+            hidden: snapshot.hidden.sorted(),
+            catalog: catalog
+        )
+    }
+
+    private static func appVersion(_ options: Options) -> String? {
+        if let appPath = options.app {
+            let url = appBundleURL(from: URL(fileURLWithPath: (appPath as NSString).expandingTildeInPath))
+            if let bundle = Bundle(url: url),
+               let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String {
+                return version
+            }
+        }
+        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+
+    private static func writeBackupFailOpen(domain: String, snapshot: Snapshot, appVersion: String?) {
+        let document = makeDocument(
+            snapshot,
+            grid: gridSnapshot(domain: domain),
+            includeCatalog: true,
+            includePaths: true,
+            appVersion: appVersion
+        )
+        do {
+            try LaunchpadPreferenceStore.writeLayoutBackup(domain: domain, document: document)
+        } catch {
+            fputs("warning: failed to write layout backup: \(error.localizedDescription)\n", stderr)
+        }
+    }
+
+    // MARK: - I/O
+
+    private static func readInput(_ path: String?) throws -> Data {
+        if let path, path != "-" {
+            let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+            do {
+                return try Data(contentsOf: url)
+            } catch {
+                throw CLIError.io("failed to read \(path): \(error.localizedDescription)")
+            }
+        }
+        do {
+            return try FileHandle.standardInput.readToEnd() ?? Data()
+        } catch {
+            throw CLIError.io("failed to read stdin: \(error.localizedDescription)")
+        }
+    }
+
+    private static func writeOutput(_ data: Data, to path: String?) throws {
+        var payload = data
+        if payload.last != UInt8(ascii: "\n") {
+            payload.append(UInt8(ascii: "\n"))
+        }
+        if let path, path != "-" {
+            let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+            do {
+                try payload.write(to: url, options: .atomic)
+            } catch {
+                throw CLIError.io("failed to write \(path): \(error.localizedDescription)")
+            }
+            return
+        }
+        FileHandle.standardOutput.write(payload)
+    }
+
+    private static func isStandardStream(_ path: String?) -> Bool {
+        path == nil || path == "-"
+    }
+
+    private static func shouldPretty(_ options: Options, writingToStdout: Bool) throws -> Bool {
+        if options.pretty && options.compact {
+            throw CLIError.usage("--pretty and --compact are mutually exclusive")
+        }
+        if options.pretty { return true }
+        if options.compact { return false }
+        if writingToStdout {
+            return isatty(STDOUT_FILENO) != 0
+        }
+        return true
+    }
+
+    private static func printReport(_ report: LaunchpadLayoutReport, wouldWriteDomain: String?) {
+        let rootApps = max(0, report.importedRootItems - report.importedFolders)
+        let referenced = report.resolvedApps + report.skippedUnknown.count
+        fputs(
+            """
+            imported: \(report.importedRootItems) items (\(report.importedFolders) folders, \(rootApps) root apps)
+            resolved: \(report.resolvedApps) / \(referenced) referenced ids
+            skippedUnknown: \(formatList(report.skippedUnknown))
+            appendedLeftover: \(formatList(report.appendedLeftover))
+            hiddenReplaced: \(report.hiddenReplaced)
+            unhiddenByClaim: \(formatList(report.unhiddenByClaim))
+            newlyHiddenByReplace: \(formatList(report.newlyHiddenByReplace))
+
+            """,
+            stdout
+        )
+        if let wouldWriteDomain {
+            fputs("wouldWriteDomain: \(wouldWriteDomain)\n", stdout)
+        }
+    }
+
+    private static func formatList(_ ids: [String]) -> String {
+        ids.isEmpty ? "(none)" : ids.joined(separator: ", ")
+    }
+
+    // MARK: - Args
+
+    private struct Options {
+        var out: String?
+        var input: String?
+        var pretty = false
+        var compact = false
+        var includeCatalog = true
+        var includePaths = true
+        var domain: String?
+        var app: String?
+        var dev = false
+        var merge = false
+        var replace = false
+        var strict = false
+        var dryRun = false
+        var help = false
+    }
+
+    private static func parseOptions(_ args: [String], command: String) throws -> Options {
+        var options = Options()
+        var index = 0
+        while index < args.count {
+            let arg = args[index]
+            if arg == "-h" || arg == "--help" {
+                options.help = true
+                index += 1
+                continue
+            }
+            switch arg {
+            case "--out":
+                options.out = try takeValue(arg, args: args, index: &index)
+            case "--in":
+                options.input = try takeValue(arg, args: args, index: &index)
+            case "--domain":
+                options.domain = try takeValue(arg, args: args, index: &index)
+            case "--app":
+                options.app = try takeValue(arg, args: args, index: &index)
+            case "--pretty":
+                options.pretty = true
+                index += 1
+            case "--compact":
+                options.compact = true
+                index += 1
+            case "--no-catalog":
+                options.includeCatalog = false
+                index += 1
+            case "--no-paths":
+                options.includePaths = false
+                index += 1
+            case "--dev":
+                options.dev = true
+                index += 1
+            case "--merge":
+                options.merge = true
+                index += 1
+            case "--replace":
+                options.replace = true
+                index += 1
+            case "--strict":
+                options.strict = true
+                index += 1
+            case "--dry-run":
+                options.dryRun = true
+                index += 1
+            default:
+                if arg.hasPrefix("--out=") {
+                    options.out = String(arg.dropFirst("--out=".count))
+                    index += 1
+                } else if arg.hasPrefix("--in=") {
+                    options.input = String(arg.dropFirst("--in=".count))
+                    index += 1
+                } else if arg.hasPrefix("--domain=") {
+                    options.domain = String(arg.dropFirst("--domain=".count))
+                    index += 1
+                } else if arg.hasPrefix("--app=") {
+                    options.app = String(arg.dropFirst("--app=".count))
+                    index += 1
+                } else {
+                    throw CLIError.usage("unexpected argument '\(arg)'")
+                }
+            }
+        }
+
+        switch command {
+        case "export":
+            if options.input != nil || options.merge || options.replace || options.strict || options.dryRun {
+                throw CLIError.usage("export does not accept --in / --merge / --replace / --strict / --dry-run")
+            }
+        case "import":
+            if options.out != nil || options.pretty || options.compact
+                || !options.includeCatalog || !options.includePaths {
+                throw CLIError.usage("import does not accept --out / --pretty / --compact / --no-catalog / --no-paths")
+            }
+        case "validate":
+            if options.out != nil || options.pretty || options.compact
+                || !options.includeCatalog || !options.includePaths
+                || options.domain != nil || options.app != nil || options.dev
+                || options.merge || options.replace || options.strict || options.dryRun {
+                throw CLIError.usage("validate only accepts --in")
+            }
+        default:
+            break
+        }
+
+        if options.pretty && options.compact {
+            throw CLIError.usage("--pretty and --compact are mutually exclusive")
+        }
+        if options.merge && options.replace {
+            throw CLIError.usage("--merge and --replace are mutually exclusive")
+        }
+        return options
+    }
+
+    private static func takeValue(_ flag: String, args: [String], index: inout Int) throws -> String {
+        let next = index + 1
+        guard next < args.count else {
+            throw CLIError.usage("\(flag) requires a value")
+        }
+        let value = args[next]
+        if value.hasPrefix("--") && value != "-" {
+            throw CLIError.usage("\(flag) requires a value")
+        }
+        index = next + 1
+        return value
+    }
+
+    private static func describe(_ error: LaunchpadLayoutError) -> String {
+        switch error {
+        case .invalidKind(let kind):
+            return "invalid kind: \(kind)"
+        case .unsupportedSchemaVersion(let version):
+            return "unsupported schemaVersion: \(version)"
+        case .malformed(let reason):
+            return "malformed: \(reason)"
+        case .limitExceeded(let limit):
+            return "limit exceeded: \(limit)"
+        case .duplicateID(let id):
+            return "duplicate id: \(id)"
+        case .nestedFolder(let id):
+            return "nested folder: \(id)"
+        case .itemHiddenOverlap(let id):
+            return "item overlaps hidden: \(id)"
+        case .strictUnresolved(let ids):
+            return "strict: unresolved ids: \(ids.joined(separator: ", "))"
+        }
+    }
+
+    private static let usageText = """
+    QLaunchpad export   [--out <path>|-] [--pretty|--compact]
+                        [--no-catalog] [--no-paths]
+                        [--domain <bundle-id>] [--dev]
+                        [--app <QLaunch.app>]
+
+    QLaunchpad import   [--in <path>|-] [--merge|--replace] [--strict] [--dry-run]
+                        [--domain <bundle-id>] [--dev]
+                        [--app <QLaunch.app>]
+
+    QLaunchpad validate [--in <path>|-]
+    QLaunchpad help
+
+    """
+
+    private enum CLIError: Error {
+        case usage(String)
+        case validate(String)
+        case io(String)
+        case prefsUnavailable(String)
+
+        var message: String {
+            switch self {
+            case .usage(let text), .validate(let text), .io(let text), .prefsUnavailable(let text):
+                return text
+            }
+        }
+
+        var exitCode: Int32 {
+            switch self {
+            case .usage: 1
+            case .validate: 2
+            case .io: 3
+            case .prefsUnavailable: 4
+            }
+        }
+    }
+}

--- a/Sources/QLaunchpad/LaunchpadUI.swift
+++ b/Sources/QLaunchpad/LaunchpadUI.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 extension Notification.Name {
     static let qlaunchpadStoreChanged = Notification.Name("QLaunchpadStoreChanged")
+    static let qlaunchpadLayoutDidChange = Notification.Name("com.qzrzz.qlaunchpad.layoutDidChange")
     static let qlaunchpadDismiss = Notification.Name("QLaunchpadDismiss")
     static let qlaunchpadPresentationChanged = Notification.Name("QLaunchpadPresentationChanged")
     static let qlaunchpadFocusSearch = Notification.Name("QLaunchpadFocusSearch")

--- a/Sources/QLaunchpad/MetalRenderer.swift
+++ b/Sources/QLaunchpad/MetalRenderer.swift
@@ -171,6 +171,7 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
 
     private var dragSource: Int?
     private var draggedAppID: String?
+    private var dragGeneration: UInt64 = 0
     private var dragDestination: Int?
     private var dragStart: CGPoint = .zero
     /// Current pointer position in top-left view coordinates.
@@ -798,6 +799,9 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
     }
 
     @objc private func storeChanged() {
+        if isDragCancelledByLayout {
+            discardCancelledDrag()
+        }
         resourcePrewarmSignature = nil
         scheduleResourcePrewarmingIfNeeded(prune: true)
         startDisplayLink()
@@ -2409,9 +2413,24 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
         contentTransitionPhase == .fadingOut ? frozenPageOffset : currentPageOffset
     }
 
+    private var isDragCancelledByLayout: Bool {
+        dragGeneration != store.dragGeneration
+    }
+
+    private func discardCancelledDrag() {
+        dragSource = nil
+        draggedAppID = nil
+        dragDestination = nil
+        dragHoverTargetID = nil
+        dragHoverVisualTargetID = nil
+        didDrag = false
+        store.setFolderDragState(isDragging: false)
+    }
+
     override func mouseDown(with event: NSEvent) {
         dragStart = convert(event.locationInWindow, from: nil)
         draggedAppID = nil
+        dragGeneration = store.dragGeneration
         dragPoint = CGPoint(x: dragStart.x, y: bounds.height - dragStart.y)
         dragGrabOffset = .zero
         edgePageDirection = 0
@@ -2680,6 +2699,10 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
     }
 
     override func mouseDragged(with event: NSEvent) {
+        if isDragCancelledByLayout {
+            discardCancelledDrag()
+            return
+        }
         let point = convert(event.locationInWindow, from: nil)
         dragPoint = CGPoint(x: point.x, y: bounds.height - point.y)
         if hypot(point.x - dragStart.x, point.y - dragStart.y) > 6 { didDrag = true }
@@ -2720,6 +2743,13 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
             isPanningPage = false
             store.setFolderDragState(isDragging: false)
             needsDisplay = true
+        }
+        if isDragCancelledByLayout {
+            if isPanningPage {
+                store.endPagePan()
+            }
+            discardCancelledDrag()
+            return
         }
         if isPanningPage {
             store.endPagePan()

--- a/Sources/QLaunchpad/QLaunchpadMain.swift
+++ b/Sources/QLaunchpad/QLaunchpadMain.swift
@@ -1,8 +1,14 @@
 import AppKit
+import Darwin
 
 @main
 enum QLaunchpadMain {
     static func main() {
+        let args = Array(CommandLine.arguments.dropFirst())
+        if LaunchpadCLI.isInvocation(args) {
+            Darwin.exit(LaunchpadCLI.run(args))
+        }
+
         let application = NSApplication.shared
         // Packaged .app: use Icon Services (Assets.car / icns). Bare binary: flat PNG.
         if Bundle.main.bundleURL.pathExtension == "app" {

--- a/Sources/QLaunchpadCore/AppFolder.swift
+++ b/Sources/QLaunchpadCore/AppFolder.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A user-created group of applications. Folder membership is stored by the
+/// stable identifier used by `AppInfo`, so rescanning applications does not
+/// invalidate folders.
+public struct AppFolder: Identifiable, Hashable, Codable, Sendable {
+    public let id: String
+    public var name: String
+    public var appIDs: [String]
+
+    public init(id: String = "folder-\(UUID().uuidString)", name: String = "文件夹", appIDs: [String]) {
+        self.id = id
+        self.name = name
+        self.appIDs = appIDs
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadCLIInvocation.swift
+++ b/Sources/QLaunchpadCore/LaunchpadCLIInvocation.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+/// Argv parsing and fail-closed domain resolution shared by the CLI and tests.
+public enum LaunchpadCLIInvocation {
+    public static let commandNames: Set<String> = ["export", "import", "validate"]
+    public static let helpNames: Set<String> = ["help", "-h", "--help"]
+
+    public static let releaseDomain = LaunchpadPreferenceStore.releaseDomain
+    public static let developmentDomain = LaunchpadPreferenceStore.developmentDomain
+
+    public static func isInvocation(_ args: [String]) -> Bool {
+        guard let first = args.first else { return false }
+        if commandNames.contains(first) || helpNames.contains(first) {
+            return true
+        }
+        return args.contains("--cli")
+    }
+
+    public struct Options: Equatable, Sendable {
+        public var out: String?
+        public var input: String?
+        public var pretty = false
+        public var compact = false
+        public var includeCatalog = true
+        public var includePaths = true
+        public var domain: String?
+        public var app: String?
+        public var dev = false
+        public var merge = false
+        public var replace = false
+        public var strict = false
+        public var dryRun = false
+        public var help = false
+
+        public init() {}
+    }
+
+    public enum ParseError: Error, Equatable {
+        case usage(String)
+
+        public var message: String {
+            switch self {
+            case .usage(let text):
+                return text
+            }
+        }
+    }
+
+    public static func parse(_ rawArgs: [String]) throws -> (command: String, options: Options) {
+        let args = rawArgs.filter { $0 != "--cli" }
+        guard let command = args.first else {
+            throw ParseError.usage("missing command")
+        }
+        if helpNames.contains(command) {
+            var options = Options()
+            options.help = true
+            return (command, options)
+        }
+        guard commandNames.contains(command) else {
+            throw ParseError.usage("unknown command '\(command)'")
+        }
+        let options = try parseOptions(Array(args.dropFirst()), command: command)
+        return (command, options)
+    }
+
+    public static func resolveDomain(
+        explicitDomain: String?,
+        appIdentifier: String?,
+        dev: Bool,
+        bundledIdentifier: String?
+    ) throws -> String {
+        if let domain = explicitDomain?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !domain.isEmpty {
+            return domain
+        }
+        if let appIdentifier {
+            let trimmed = appIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        if dev {
+            return developmentDomain
+        }
+        if let bundledIdentifier, isPackagedDomain(bundledIdentifier) {
+            return bundledIdentifier
+        }
+        throw ParseError.usage(
+            "preference domain is required when not running from a packaged QLaunch.app / QLaunch Dev.app; use --domain, --dev, or --app"
+        )
+    }
+
+    public static func isPackagedDomain(_ identifier: String) -> Bool {
+        identifier == releaseDomain || identifier == developmentDomain
+    }
+
+    public static func shouldPretty(
+        pretty: Bool,
+        compact: Bool,
+        writingToStdout: Bool,
+        stdoutIsTTY: Bool
+    ) throws -> Bool {
+        if pretty && compact {
+            throw ParseError.usage("--pretty and --compact are mutually exclusive")
+        }
+        if pretty { return true }
+        if compact { return false }
+        if writingToStdout {
+            return stdoutIsTTY
+        }
+        return true
+    }
+
+    private static func parseOptions(_ args: [String], command: String) throws -> Options {
+        var options = Options()
+        var index = 0
+        while index < args.count {
+            let arg = args[index]
+            if arg == "-h" || arg == "--help" {
+                options.help = true
+                index += 1
+                continue
+            }
+            switch arg {
+            case "--out":
+                options.out = try takeValue(arg, args: args, index: &index)
+            case "--in":
+                options.input = try takeValue(arg, args: args, index: &index)
+            case "--domain":
+                options.domain = try takeValue(arg, args: args, index: &index)
+            case "--app":
+                options.app = try takeValue(arg, args: args, index: &index)
+            case "--pretty":
+                options.pretty = true
+                index += 1
+            case "--compact":
+                options.compact = true
+                index += 1
+            case "--no-catalog":
+                options.includeCatalog = false
+                index += 1
+            case "--no-paths":
+                options.includePaths = false
+                index += 1
+            case "--dev":
+                options.dev = true
+                index += 1
+            case "--merge":
+                options.merge = true
+                index += 1
+            case "--replace":
+                options.replace = true
+                index += 1
+            case "--strict":
+                options.strict = true
+                index += 1
+            case "--dry-run":
+                options.dryRun = true
+                index += 1
+            default:
+                if arg.hasPrefix("--out=") {
+                    options.out = String(arg.dropFirst("--out=".count))
+                    index += 1
+                } else if arg.hasPrefix("--in=") {
+                    options.input = String(arg.dropFirst("--in=".count))
+                    index += 1
+                } else if arg.hasPrefix("--domain=") {
+                    options.domain = String(arg.dropFirst("--domain=".count))
+                    index += 1
+                } else if arg.hasPrefix("--app=") {
+                    options.app = String(arg.dropFirst("--app=".count))
+                    index += 1
+                } else {
+                    throw ParseError.usage("unexpected argument '\(arg)'")
+                }
+            }
+        }
+
+        switch command {
+        case "export":
+            if options.input != nil || options.merge || options.replace || options.strict || options.dryRun {
+                throw ParseError.usage("export does not accept --in / --merge / --replace / --strict / --dry-run")
+            }
+        case "import":
+            if options.out != nil || options.pretty || options.compact
+                || !options.includeCatalog || !options.includePaths {
+                throw ParseError.usage("import does not accept --out / --pretty / --compact / --no-catalog / --no-paths")
+            }
+        case "validate":
+            if options.out != nil || options.pretty || options.compact
+                || !options.includeCatalog || !options.includePaths
+                || options.domain != nil || options.app != nil || options.dev
+                || options.merge || options.replace || options.strict || options.dryRun {
+                throw ParseError.usage("validate only accepts --in")
+            }
+        default:
+            break
+        }
+
+        if options.pretty && options.compact {
+            throw ParseError.usage("--pretty and --compact are mutually exclusive")
+        }
+        if options.merge && options.replace {
+            throw ParseError.usage("--merge and --replace are mutually exclusive")
+        }
+        return options
+    }
+
+    private static func takeValue(_ flag: String, args: [String], index: inout Int) throws -> String {
+        let next = index + 1
+        guard next < args.count else {
+            throw ParseError.usage("\(flag) requires a value")
+        }
+        let value = args[next]
+        if value.hasPrefix("--") && value != "-" {
+            throw ParseError.usage("\(flag) requires a value")
+        }
+        index = next + 1
+        return value
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadLayout.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayout.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+public enum LaunchpadLayoutKind {
+    public static let current = "qlaunchpad.layout"
+    public static let schemaVersion = 1
+}
+
+public struct LaunchpadLayoutDocument: Equatable, Sendable {
+    public var kind: String
+    public var schemaVersion: Int
+    public var exportedAt: Date?
+    public var appVersion: String?
+    public var grid: LaunchpadLayoutGrid?
+    public var items: [LaunchpadLayoutItem]
+    public var hidden: [String]?
+    public var catalog: [LaunchpadLayoutCatalogEntry]?
+
+    public init(
+        kind: String = LaunchpadLayoutKind.current,
+        schemaVersion: Int = LaunchpadLayoutKind.schemaVersion,
+        exportedAt: Date? = nil,
+        appVersion: String? = nil,
+        grid: LaunchpadLayoutGrid? = nil,
+        items: [LaunchpadLayoutItem],
+        hidden: [String]? = nil,
+        catalog: [LaunchpadLayoutCatalogEntry]? = nil
+    ) {
+        self.kind = kind
+        self.schemaVersion = schemaVersion
+        self.exportedAt = exportedAt
+        self.appVersion = appVersion
+        self.grid = grid
+        self.items = items
+        self.hidden = hidden
+        self.catalog = catalog
+    }
+
+    /// Pretty + sortedKeys + ISO-8601. Not the on-disk folders encoder.
+    public static func makeEncoder(pretty: Bool = true) -> JSONEncoder {
+        let encoder = JSONEncoder()
+        var formatting: JSONEncoder.OutputFormatting = [.sortedKeys]
+        if pretty {
+            formatting.insert(.prettyPrinted)
+        }
+        encoder.outputFormatting = formatting
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    public static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+public enum LaunchpadLayoutItem: Equatable, Sendable {
+    case app(id: String)
+    case folder(id: String?, name: String, apps: [String])
+}
+
+public struct LaunchpadLayoutGrid: Codable, Equatable, Sendable {
+    public var preset: String
+    public var columns: Int
+    public var rows: Int
+    public var pageCapacity: Int
+
+    public init(preset: String, columns: Int, rows: Int, pageCapacity: Int) {
+        self.preset = preset
+        self.columns = columns
+        self.rows = rows
+        self.pageCapacity = pageCapacity
+    }
+}
+
+public struct LaunchpadLayoutCatalogEntry: Codable, Equatable, Sendable {
+    public var id: String
+    public var bundleIdentifier: String
+    public var name: String
+    public var path: String?
+
+    public init(id: String, bundleIdentifier: String, name: String, path: String? = nil) {
+        self.id = id
+        self.bundleIdentifier = bundleIdentifier
+        self.name = name
+        self.path = path
+    }
+}
+
+public struct LaunchpadKnownApp: Equatable, Sendable {
+    public var id: String
+    public var bundleIdentifier: String
+    public var name: String
+    public var path: String
+
+    public init(id: String, bundleIdentifier: String, name: String, path: String) {
+        self.id = id
+        self.bundleIdentifier = bundleIdentifier
+        self.name = name
+        self.path = path
+    }
+}
+
+public enum LaunchpadLayoutImportMode: String, Sendable {
+    case merge
+    case replace
+}
+
+public struct LaunchpadLayoutReport: Equatable, Sendable {
+    public var importedRootItems: Int
+    public var importedFolders: Int
+    public var resolvedApps: Int
+    public var skippedUnknown: [String]
+    public var appendedLeftover: [String]
+    public var hiddenReplaced: Bool
+    public var unhiddenByClaim: [String]
+    public var newlyHiddenByReplace: [String]
+
+    public init(
+        importedRootItems: Int,
+        importedFolders: Int,
+        resolvedApps: Int,
+        skippedUnknown: [String],
+        appendedLeftover: [String],
+        hiddenReplaced: Bool,
+        unhiddenByClaim: [String],
+        newlyHiddenByReplace: [String]
+    ) {
+        self.importedRootItems = importedRootItems
+        self.importedFolders = importedFolders
+        self.resolvedApps = resolvedApps
+        self.skippedUnknown = skippedUnknown
+        self.appendedLeftover = appendedLeftover
+        self.hiddenReplaced = hiddenReplaced
+        self.unhiddenByClaim = unhiddenByClaim
+        self.newlyHiddenByReplace = newlyHiddenByReplace
+    }
+}
+
+public enum LaunchpadLayoutError: Error, Equatable {
+    case invalidKind(String)
+    case unsupportedSchemaVersion(Int)
+    case malformed(String)
+    case limitExceeded(String)
+    case duplicateID(String)
+    case nestedFolder(String)
+    case itemHiddenOverlap(String)
+    case strictUnresolved([String])
+}
+
+extension LaunchpadLayoutDocument: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case schemaVersion
+        case exportedAt
+        case appVersion
+        case grid
+        case items
+        case hidden
+        case catalog
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try container.decode(String.self, forKey: .kind)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        exportedAt = try container.decodeIfPresent(Date.self, forKey: .exportedAt)
+        appVersion = try container.decodeIfPresent(String.self, forKey: .appVersion)
+        grid = try container.decodeIfPresent(LaunchpadLayoutGrid.self, forKey: .grid)
+        items = try container.decode([LaunchpadLayoutItem].self, forKey: .items)
+        hidden = try container.decodeIfPresent([String].self, forKey: .hidden)
+        catalog = try container.decodeIfPresent([LaunchpadLayoutCatalogEntry].self, forKey: .catalog)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encodeIfPresent(exportedAt, forKey: .exportedAt)
+        try container.encodeIfPresent(appVersion, forKey: .appVersion)
+        try container.encodeIfPresent(grid, forKey: .grid)
+        try container.encode(items, forKey: .items)
+        try container.encodeIfPresent(hidden, forKey: .hidden)
+        try container.encodeIfPresent(catalog, forKey: .catalog)
+    }
+}
+
+extension LaunchpadLayoutItem: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case id
+        case name
+        case apps
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "app":
+            self = .app(id: try container.decode(String.self, forKey: .id))
+        case "folder":
+            self = .folder(
+                id: try container.decodeIfPresent(String.self, forKey: .id),
+                name: try container.decode(String.self, forKey: .name),
+                apps: try container.decode([String].self, forKey: .apps)
+            )
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unsupported layout item type '\(type)'"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .app(let id):
+            try container.encode("app", forKey: .type)
+            try container.encode(id, forKey: .id)
+        case .folder(let id, let name, let apps):
+            try container.encode("folder", forKey: .type)
+            try container.encodeIfPresent(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(apps, forKey: .apps)
+        }
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadLayoutImporter.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayoutImporter.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+public enum LaunchpadLayoutImporter {
+    public static let maxJSONBytes = 5 * 1024 * 1024
+    public static let maxItems = 10_000
+    public static let maxFolders = 2_000
+    public static let maxFolderMembers = 500
+    public static let maxNameScalars = 200
+    public static let maxCatalogEntries = 10_000
+
+    public static func apply(
+        document: LaunchpadLayoutDocument,
+        mode: LaunchpadLayoutImportMode,
+        strict: Bool,
+        scanned: [LaunchpadKnownApp],
+        currentHidden: Set<String>
+    ) throws -> (
+        layout: (folders: [AppFolder], order: [String], hidden: Set<String>),
+        report: LaunchpadLayoutReport
+    ) {
+        try validate(document)
+
+        var resolvedByRawID: [String: LaunchpadKnownApp] = [:]
+        var skippedUnknown: [String] = []
+        var seenReferenced = Set<String>()
+        for rawID in referencedIDs(in: document) {
+            guard seenReferenced.insert(rawID).inserted else { continue }
+            if let resolved = LaunchpadLayoutResolver.resolve(
+                rawID: rawID,
+                scanned: scanned,
+                catalog: document.catalog
+            ) {
+                resolvedByRawID[rawID] = resolved
+            } else {
+                skippedUnknown.append(rawID)
+            }
+        }
+
+        if strict {
+            if !skippedUnknown.isEmpty {
+                throw LaunchpadLayoutError.strictUnresolved(skippedUnknown)
+            }
+            for item in document.items {
+                if case .folder(_, let name, _) = item,
+                   name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    throw LaunchpadLayoutError.malformed("empty folder name")
+                }
+            }
+        }
+
+        var proposedFolders: [AppFolder] = []
+        var proposedOrder: [String] = []
+        for item in document.items {
+            switch item {
+            case .app(let rawID):
+                guard let resolved = resolvedByRawID[rawID] else { continue }
+                proposedOrder.append(resolved.id)
+            case .folder(let rawID, let name, let apps):
+                let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+                let folderName = trimmedName.isEmpty ? "文件夹" : trimmedName
+                let folderID = normalizedFolderID(rawID)
+                let members = apps.compactMap { resolvedByRawID[$0]?.id }
+                proposedFolders.append(AppFolder(id: folderID, name: folderName, appIDs: members))
+                proposedOrder.append(folderID)
+            }
+        }
+
+        let resolvedAppIDs = Set(resolvedByRawID.values.map(\.id))
+        for folder in proposedFolders where resolvedAppIDs.contains(folder.id) {
+            throw LaunchpadLayoutError.duplicateID(folder.id)
+        }
+
+        var claimedIDs = Set<String>()
+        for folder in proposedFolders {
+            claimedIDs.formUnion(folder.appIDs)
+        }
+        let folderIDs = Set(proposedFolders.map(\.id))
+        for id in proposedOrder where !folderIDs.contains(id) {
+            claimedIDs.insert(id)
+        }
+
+        let hiddenReplaced = document.hidden != nil
+        let hiddenBaseline: Set<String>
+        let unhiddenByClaim: [String]
+        if let hidden = document.hidden {
+            hiddenBaseline = Set(hidden.compactMap { resolvedByRawID[$0]?.id })
+            unhiddenByClaim = []
+            for id in claimedIDs where hiddenBaseline.contains(id) {
+                throw LaunchpadLayoutError.itemHiddenOverlap(id)
+            }
+        } else {
+            hiddenBaseline = currentHidden.subtracting(claimedIDs)
+            unhiddenByClaim = currentHidden.intersection(claimedIDs).sorted()
+        }
+
+        let leftoverIDs = scanned
+            .filter { !claimedIDs.contains($0.id) && !hiddenBaseline.contains($0.id) }
+            .sorted(by: Self.appSort)
+            .map(\.id)
+
+        let newlyHiddenByReplace: [String]
+        let finalHidden: Set<String>
+        if mode == .replace {
+            newlyHiddenByReplace = leftoverIDs
+            finalHidden = hiddenBaseline.union(leftoverIDs)
+        } else {
+            newlyHiddenByReplace = []
+            finalHidden = hiddenBaseline
+        }
+
+        let reconciled = LaunchpadLayoutReconciler.reconcile(
+            apps: scanned,
+            folders: proposedFolders,
+            order: proposedOrder,
+            hidden: finalHidden
+        )
+
+        let leftoverInOrder = mode == .merge ? leftoverIDs : []
+        let report = LaunchpadLayoutReport(
+            importedRootItems: reconciled.order.count - leftoverInOrder.count,
+            importedFolders: reconciled.folders.count,
+            resolvedApps: resolvedByRawID.count,
+            skippedUnknown: skippedUnknown,
+            appendedLeftover: leftoverInOrder,
+            hiddenReplaced: hiddenReplaced,
+            unhiddenByClaim: unhiddenByClaim,
+            newlyHiddenByReplace: newlyHiddenByReplace
+        )
+        return (
+            layout: (folders: reconciled.folders, order: reconciled.order, hidden: finalHidden),
+            report: report
+        )
+    }
+
+    public static func validate(_ document: LaunchpadLayoutDocument) throws {
+        if document.kind != LaunchpadLayoutKind.current {
+            throw LaunchpadLayoutError.invalidKind(document.kind)
+        }
+        if document.schemaVersion != LaunchpadLayoutKind.schemaVersion {
+            throw LaunchpadLayoutError.unsupportedSchemaVersion(document.schemaVersion)
+        }
+        if document.items.count > maxItems {
+            throw LaunchpadLayoutError.limitExceeded("items")
+        }
+        let folderCount = document.items.reduce(0) { count, item in
+            if case .folder = item { return count + 1 }
+            return count
+        }
+        if folderCount > maxFolders {
+            throw LaunchpadLayoutError.limitExceeded("folders")
+        }
+        if let catalog = document.catalog, catalog.count > maxCatalogEntries {
+            throw LaunchpadLayoutError.limitExceeded("catalog")
+        }
+
+        var folderIDs = Set<String>()
+        for item in document.items {
+            if case .folder(let id, _, _) = item, let id {
+                try rejectInvalidString(id)
+                folderIDs.insert(id)
+            }
+        }
+
+        var seenIDs = Set<String>()
+        for item in document.items {
+            switch item {
+            case .app(let id):
+                try rejectInvalidString(id)
+                if !seenIDs.insert(id).inserted {
+                    throw LaunchpadLayoutError.duplicateID(id)
+                }
+            case .folder(let id, let name, let apps):
+                if name.unicodeScalars.contains("\0") {
+                    throw LaunchpadLayoutError.malformed("string contains NUL")
+                }
+                if name.unicodeScalars.count > maxNameScalars {
+                    throw LaunchpadLayoutError.limitExceeded("name")
+                }
+                if let id {
+                    if !seenIDs.insert(id).inserted {
+                        throw LaunchpadLayoutError.duplicateID(id)
+                    }
+                }
+                if apps.count > maxFolderMembers {
+                    throw LaunchpadLayoutError.limitExceeded("folder members")
+                }
+                for appID in apps {
+                    try rejectInvalidString(appID)
+                    if folderIDs.contains(appID) {
+                        throw LaunchpadLayoutError.nestedFolder(appID)
+                    }
+                    if !seenIDs.insert(appID).inserted {
+                        throw LaunchpadLayoutError.duplicateID(appID)
+                    }
+                }
+            }
+        }
+
+        if let hidden = document.hidden {
+            var seenHidden = Set<String>()
+            for id in hidden {
+                try rejectInvalidString(id)
+                if !seenHidden.insert(id).inserted {
+                    throw LaunchpadLayoutError.duplicateID(id)
+                }
+                if seenIDs.contains(id) {
+                    throw LaunchpadLayoutError.itemHiddenOverlap(id)
+                }
+            }
+        }
+
+        if let catalog = document.catalog {
+            for entry in catalog {
+                try rejectInvalidString(entry.id)
+                try rejectInvalidString(entry.bundleIdentifier)
+                try rejectInvalidString(entry.name)
+                if let path = entry.path {
+                    try rejectInvalidString(path)
+                }
+            }
+        }
+    }
+
+    public static func validateJSONSize(_ data: Data) throws {
+        if data.count > maxJSONBytes {
+            throw LaunchpadLayoutError.limitExceeded("json")
+        }
+    }
+
+    private static func referencedIDs(in document: LaunchpadLayoutDocument) -> [String] {
+        var ids: [String] = []
+        for item in document.items {
+            switch item {
+            case .app(let id):
+                ids.append(id)
+            case .folder(_, _, let apps):
+                ids.append(contentsOf: apps)
+            }
+        }
+        if let hidden = document.hidden {
+            ids.append(contentsOf: hidden)
+        }
+        return ids
+    }
+
+    private static func normalizedFolderID(_ rawID: String?) -> String {
+        guard let rawID else {
+            return "folder-\(UUID().uuidString)"
+        }
+        let trimmed = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "folder-\(UUID().uuidString)" : trimmed
+    }
+
+    private static func rejectInvalidString(_ value: String) throws {
+        if value.unicodeScalars.contains("\0") {
+            throw LaunchpadLayoutError.malformed("string contains NUL")
+        }
+        if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw LaunchpadLayoutError.malformed("empty string")
+        }
+    }
+
+    private static func appSort(_ lhs: LaunchpadKnownApp, _ rhs: LaunchpadKnownApp) -> Bool {
+        let nameOrder = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+        if nameOrder != .orderedSame {
+            return nameOrder == .orderedAscending
+        }
+        return lhs.path < rhs.path
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadLayoutImporter.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayoutImporter.swift
@@ -36,6 +36,14 @@ public enum LaunchpadLayoutImporter {
             }
         }
 
+        var seenResolvedIDs = Set<String>()
+        for rawID in referencedIDs(in: document, includeHidden: false) {
+            guard let resolved = resolvedByRawID[rawID] else { continue }
+            if !seenResolvedIDs.insert(resolved.id).inserted {
+                throw LaunchpadLayoutError.duplicateID(resolved.id)
+            }
+        }
+
         if strict {
             if !skippedUnknown.isEmpty {
                 throw LaunchpadLayoutError.strictUnresolved(skippedUnknown)
@@ -65,8 +73,8 @@ public enum LaunchpadLayoutImporter {
             }
         }
 
-        let resolvedAppIDs = Set(resolvedByRawID.values.map(\.id))
-        for folder in proposedFolders where resolvedAppIDs.contains(folder.id) {
+        let scannedIDs = Set(scanned.map(\.id))
+        for folder in proposedFolders where scannedIDs.contains(folder.id) {
             throw LaunchpadLayoutError.duplicateID(folder.id)
         }
 
@@ -157,7 +165,10 @@ public enum LaunchpadLayoutImporter {
         for item in document.items {
             if case .folder(let id, _, _) = item, let id {
                 try rejectInvalidString(id)
-                folderIDs.insert(id)
+                let identity = folderIdentity(id)
+                if !folderIDs.insert(identity).inserted {
+                    throw LaunchpadLayoutError.duplicateID(identity)
+                }
             }
         }
 
@@ -177,8 +188,9 @@ public enum LaunchpadLayoutImporter {
                     throw LaunchpadLayoutError.limitExceeded("name")
                 }
                 if let id {
-                    if !seenIDs.insert(id).inserted {
-                        throw LaunchpadLayoutError.duplicateID(id)
+                    let identity = folderIdentity(id)
+                    if !seenIDs.insert(identity).inserted {
+                        throw LaunchpadLayoutError.duplicateID(identity)
                     }
                 }
                 if apps.count > maxFolderMembers {
@@ -186,7 +198,7 @@ public enum LaunchpadLayoutImporter {
                 }
                 for appID in apps {
                     try rejectInvalidString(appID)
-                    if folderIDs.contains(appID) {
+                    if folderIDs.contains(folderIdentity(appID)) {
                         throw LaunchpadLayoutError.nestedFolder(appID)
                     }
                     if !seenIDs.insert(appID).inserted {
@@ -227,7 +239,10 @@ public enum LaunchpadLayoutImporter {
         }
     }
 
-    private static func referencedIDs(in document: LaunchpadLayoutDocument) -> [String] {
+    private static func referencedIDs(
+        in document: LaunchpadLayoutDocument,
+        includeHidden: Bool = true
+    ) -> [String] {
         var ids: [String] = []
         for item in document.items {
             switch item {
@@ -237,17 +252,21 @@ public enum LaunchpadLayoutImporter {
                 ids.append(contentsOf: apps)
             }
         }
-        if let hidden = document.hidden {
+        if includeHidden, let hidden = document.hidden {
             ids.append(contentsOf: hidden)
         }
         return ids
+    }
+
+    private static func folderIdentity(_ rawID: String) -> String {
+        rawID.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func normalizedFolderID(_ rawID: String?) -> String {
         guard let rawID else {
             return "folder-\(UUID().uuidString)"
         }
-        let trimmed = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = folderIdentity(rawID)
         return trimmed.isEmpty ? "folder-\(UUID().uuidString)" : trimmed
     }
 

--- a/Sources/QLaunchpadCore/LaunchpadLayoutReconciler.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayoutReconciler.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public enum LaunchpadLayoutReconciler {
+    /// Matches `AppStore.reconcileLaunchpadItems()`: drop empty folders, strip
+    /// hidden members, keep the first copy of a duplicated app, append folders
+    /// missing from `order` before leftover apps.
+    public static func reconcile(
+        apps: [LaunchpadKnownApp],
+        folders: [AppFolder],
+        order: [String],
+        hidden: Set<String>
+    ) -> (folders: [AppFolder], order: [String]) {
+        let validApps = Set(apps.map(\.id)).subtracting(hidden)
+        var usedAppIDs = Set<String>()
+        var sanitizedFolders: [AppFolder] = []
+        for folder in folders {
+            let members = folder.appIDs.filter { validApps.contains($0) && usedAppIDs.insert($0).inserted }
+            guard !members.isEmpty else { continue }
+            var sanitized = folder
+            sanitized.appIDs = members
+            sanitizedFolders.append(sanitized)
+        }
+
+        let folderByID = Dictionary(uniqueKeysWithValues: sanitizedFolders.map { ($0.id, $0) })
+        var validOrder: [String] = []
+        var seen = Set<String>()
+        for id in order {
+            if let folder = folderByID[id], seen.insert(id).inserted {
+                validOrder.append(folder.id)
+            } else if validApps.contains(id), !usedAppIDs.contains(id), seen.insert(id).inserted {
+                validOrder.append(id)
+            }
+        }
+        for folder in sanitizedFolders where seen.insert(folder.id).inserted {
+            validOrder.append(folder.id)
+        }
+        for app in apps where validApps.contains(app.id)
+            && !usedAppIDs.contains(app.id)
+            && seen.insert(app.id).inserted {
+            validOrder.append(app.id)
+        }
+        return (sanitizedFolders, validOrder)
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadLayoutResolver.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayoutResolver.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+public enum LaunchpadLayoutResolver {
+    public static func resolve(
+        rawID: String,
+        scanned: [LaunchpadKnownApp],
+        catalog: [LaunchpadLayoutCatalogEntry]?
+    ) -> LaunchpadKnownApp? {
+        if let exact = scanned.first(where: { $0.id == rawID }) {
+            return exact
+        }
+
+        if let parsed = parseCompositeID(rawID) {
+            let standardized = standardizedPath(parsed.path)
+            if let match = scanned.first(where: {
+                $0.bundleIdentifier == parsed.bundle
+                    && standardizedPath($0.path) == standardized
+            }) {
+                return match
+            }
+        }
+
+        if let catalog,
+           let entry = catalog.first(where: { $0.id == rawID }),
+           let path = entry.path {
+            let standardized = standardizedPath(path)
+            if let match = scanned.first(where: {
+                $0.bundleIdentifier == entry.bundleIdentifier
+                    && standardizedPath($0.path) == standardized
+            }) {
+                return match
+            }
+        }
+
+        let bundle = parseCompositeID(rawID)?.bundle ?? rawID
+        let copies = scanned.filter { $0.bundleIdentifier == bundle }
+        if copies.count == 1 {
+            return copies[0]
+        }
+
+        return nil
+    }
+
+    private static func parseCompositeID(_ rawID: String) -> (bundle: String, path: String)? {
+        guard let hash = rawID.firstIndex(of: "#") else { return nil }
+        let bundle = String(rawID[..<hash])
+        let path = String(rawID[rawID.index(after: hash)...])
+        guard !bundle.isEmpty, !path.isEmpty else { return nil }
+        return (bundle, path)
+    }
+
+    private static func standardizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadPersistence.swift
+++ b/Sources/QLaunchpadCore/LaunchpadPersistence.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public enum LaunchpadPersistence {
+    public static let hiddenAppsKey = "hiddenAppIdentifiers"
+    public static let customSourcesKey = "customApplicationSourcePaths"
+    public static let showHiddenAppsKey = "showHiddenAppsInSearch"
+    public static let foldersKey = "launchpadFolders"
+    public static let itemOrderKey = "launchpadItemOrder"
+    public static let gridLayoutPresetKey = "gridLayoutPreset"
+
+    /// Compact `[{id,name,appIDs}]`. Key order is fixed so persist-if-changed
+    /// can compare encoded `Data` without false dirty writes.
+    public static func encodeFolders(_ folders: [AppFolder]) throws -> Data {
+        let encoder = JSONEncoder()
+        var json = Data([UInt8(ascii: "[")])
+        for (index, folder) in folders.enumerated() {
+            if index > 0 {
+                json.append(UInt8(ascii: ","))
+            }
+            json.append(UInt8(ascii: "{"))
+            json.append(contentsOf: "\"id\":".utf8)
+            json.append(try encoder.encode(folder.id))
+            json.append(contentsOf: ",\"name\":".utf8)
+            json.append(try encoder.encode(folder.name))
+            json.append(contentsOf: ",\"appIDs\":[".utf8)
+            for (appIndex, appID) in folder.appIDs.enumerated() {
+                if appIndex > 0 {
+                    json.append(UInt8(ascii: ","))
+                }
+                json.append(try encoder.encode(appID))
+            }
+            json.append(contentsOf: "]}".utf8)
+        }
+        json.append(UInt8(ascii: "]"))
+        return json
+    }
+
+    public static func decodeFolders(_ data: Data) throws -> [AppFolder] {
+        try JSONDecoder().decode([AppFolder].self, from: data)
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadPreferenceStore.swift
+++ b/Sources/QLaunchpadCore/LaunchpadPreferenceStore.swift
@@ -25,6 +25,14 @@ public enum LaunchpadPreferenceStore {
         try LaunchpadPersistence.decodeFolders(data)
     }
 
+    /// Missing key (`Data()`) is empty folders. Non-empty undecodable bytes throw.
+    public static func decodePersistedFolders(_ data: Data) throws -> [AppFolder] {
+        if data.isEmpty {
+            return []
+        }
+        return try decodeFolders(data)
+    }
+
     /// Synchronizes the domain, then copies the three layout keys. Missing keys
     /// are empty arrays / empty `Data`.
     public static func readLayout(domain: String) -> LaunchpadPersistedLayout {
@@ -39,7 +47,9 @@ public enum LaunchpadPreferenceStore {
 
     /// Writes only keys that differ. Hidden is sorted before compare / set.
     /// Folders must be `CFData` (encoded `[AppFolder]` bytes), not a JSON string.
-    public static func writeLayout(domain: String, _ layout: LaunchpadPersistedLayout) {
+    /// Returns `false` when a dirty write's `CFPreferencesAppSynchronize` fails.
+    @discardableResult
+    public static func writeLayout(domain: String, _ layout: LaunchpadPersistedLayout) -> Bool {
         let applicationID = domain as CFString
         let next = LaunchpadPersistedLayout(
             itemOrder: layout.itemOrder,
@@ -74,9 +84,12 @@ public enum LaunchpadPreferenceStore {
             changed = true
         }
         if changed {
-            CFPreferencesAppSynchronize(applicationID)
+            guard CFPreferencesAppSynchronize(applicationID) else {
+                return false
+            }
         }
         writeThroughIfCurrentDomain(domain, next)
+        return true
     }
 
     public static func persistFolders(domain: String, _ folders: [AppFolder]) {

--- a/Sources/QLaunchpadCore/LaunchpadPreferenceStore.swift
+++ b/Sources/QLaunchpadCore/LaunchpadPreferenceStore.swift
@@ -1,0 +1,170 @@
+import CoreFoundation
+import Foundation
+
+public struct LaunchpadPersistedLayout: Equatable, Sendable {
+    public var itemOrder: [String]
+    public var foldersData: Data
+    public var hiddenIDs: [String]
+
+    public init(itemOrder: [String], foldersData: Data, hiddenIDs: [String]) {
+        self.itemOrder = itemOrder
+        self.foldersData = foldersData
+        self.hiddenIDs = hiddenIDs
+    }
+}
+
+public enum LaunchpadPreferenceStore {
+    public static let releaseDomain = "com.qzrzz.qlaunchpad"
+    public static let developmentDomain = "com.qzrzz.qlaunchpad.dev"
+
+    public static func encodeFolders(_ folders: [AppFolder]) throws -> Data {
+        try LaunchpadPersistence.encodeFolders(folders)
+    }
+
+    public static func decodeFolders(_ data: Data) throws -> [AppFolder] {
+        try LaunchpadPersistence.decodeFolders(data)
+    }
+
+    /// Synchronizes the domain, then copies the three layout keys. Missing keys
+    /// are empty arrays / empty `Data`.
+    public static func readLayout(domain: String) -> LaunchpadPersistedLayout {
+        let applicationID = domain as CFString
+        CFPreferencesAppSynchronize(applicationID)
+        return LaunchpadPersistedLayout(
+            itemOrder: copyStringArray(key: LaunchpadPersistence.itemOrderKey, applicationID: applicationID),
+            foldersData: copyData(key: LaunchpadPersistence.foldersKey, applicationID: applicationID),
+            hiddenIDs: copyStringArray(key: LaunchpadPersistence.hiddenAppsKey, applicationID: applicationID)
+        )
+    }
+
+    /// Writes only keys that differ. Hidden is sorted before compare / set.
+    /// Folders must be `CFData` (encoded `[AppFolder]` bytes), not a JSON string.
+    public static func writeLayout(domain: String, _ layout: LaunchpadPersistedLayout) {
+        let applicationID = domain as CFString
+        let next = LaunchpadPersistedLayout(
+            itemOrder: layout.itemOrder,
+            foldersData: layout.foldersData,
+            hiddenIDs: layout.hiddenIDs.sorted()
+        )
+        let current = readLayout(domain: domain)
+        var changed = false
+
+        if next.itemOrder != current.itemOrder {
+            CFPreferencesSetAppValue(
+                LaunchpadPersistence.itemOrderKey as CFString,
+                next.itemOrder as CFArray,
+                applicationID
+            )
+            changed = true
+        }
+        if next.foldersData != current.foldersData {
+            CFPreferencesSetAppValue(
+                LaunchpadPersistence.foldersKey as CFString,
+                next.foldersData as CFData,
+                applicationID
+            )
+            changed = true
+        }
+        if next.hiddenIDs != current.hiddenIDs.sorted() {
+            CFPreferencesSetAppValue(
+                LaunchpadPersistence.hiddenAppsKey as CFString,
+                next.hiddenIDs as CFArray,
+                applicationID
+            )
+            changed = true
+        }
+        if changed {
+            CFPreferencesAppSynchronize(applicationID)
+        }
+        writeThroughIfCurrentDomain(domain, next)
+    }
+
+    public static func persistFolders(domain: String, _ folders: [AppFolder]) {
+        guard let foldersData = try? encodeFolders(folders) else { return }
+        var layout = readLayout(domain: domain)
+        layout.foldersData = foldersData
+        writeLayout(domain: domain, layout)
+    }
+
+    public static func persistItemOrder(domain: String, _ order: [String]) {
+        var layout = readLayout(domain: domain)
+        layout.itemOrder = order
+        writeLayout(domain: domain, layout)
+    }
+
+    public static func persistHiddenApps(domain: String, _ hidden: Set<String>) {
+        var layout = readLayout(domain: domain)
+        layout.hiddenIDs = hidden.sorted()
+        writeLayout(domain: domain, layout)
+    }
+
+    public static func readString(domain: String, key: String) -> String? {
+        let applicationID = domain as CFString
+        CFPreferencesAppSynchronize(applicationID)
+        guard let value = CFPreferencesCopyAppValue(key as CFString, applicationID) else {
+            return nil
+        }
+        return value as? String
+    }
+
+    public static func readStringArray(domain: String, key: String) -> [String] {
+        let applicationID = domain as CFString
+        CFPreferencesAppSynchronize(applicationID)
+        return copyStringArray(key: key, applicationID: applicationID)
+    }
+
+    public static func writeThroughToStandardDefaults(_ layout: LaunchpadPersistedLayout) {
+        let hidden = layout.hiddenIDs.sorted()
+        UserDefaults.standard.set(layout.itemOrder, forKey: LaunchpadPersistence.itemOrderKey)
+        UserDefaults.standard.set(layout.foldersData, forKey: LaunchpadPersistence.foldersKey)
+        UserDefaults.standard.set(hidden, forKey: LaunchpadPersistence.hiddenAppsKey)
+    }
+
+    public static func layoutBackupFileURL(domain: String) -> URL {
+        let folderName = domain == developmentDomain ? "QLaunch Dev" : "QLaunch"
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+            .appendingPathComponent(folderName, isDirectory: true)
+            .appendingPathComponent("layout.backup.json")
+    }
+
+    public static func writeLayoutBackup(domain: String, document: LaunchpadLayoutDocument) throws {
+        let data = try LaunchpadLayoutDocument.makeEncoder(pretty: true).encode(document)
+        let url = layoutBackupFileURL(domain: domain)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
+    }
+
+    private static func writeThroughIfCurrentDomain(_ domain: String, _ layout: LaunchpadPersistedLayout) {
+        let currentDomain = Bundle.main.bundleIdentifier
+            ?? (kCFPreferencesCurrentApplication as String)
+        guard domain == currentDomain else { return }
+        writeThroughToStandardDefaults(layout)
+    }
+
+    private static func copyStringArray(key: String, applicationID: CFString) -> [String] {
+        guard let value = CFPreferencesCopyAppValue(key as CFString, applicationID) else {
+            return []
+        }
+        if let strings = value as? [String] {
+            return strings
+        }
+        if let array = value as? NSArray {
+            return array.compactMap { $0 as? String }
+        }
+        return []
+    }
+
+    private static func copyData(key: String, applicationID: CFString) -> Data {
+        guard let value = CFPreferencesCopyAppValue(key as CFString, applicationID) else {
+            return Data()
+        }
+        if let data = value as? Data {
+            return data
+        }
+        return Data()
+    }
+}

--- a/Tests/QLaunchpadCoreTests/Fixtures/canonical-layout.json
+++ b/Tests/QLaunchpadCoreTests/Fixtures/canonical-layout.json
@@ -1,0 +1,48 @@
+{
+  "appVersion" : "1.0.0",
+  "catalog" : [
+    {
+      "bundleIdentifier" : "com.apple.Safari",
+      "id" : "com.apple.Safari",
+      "name" : "Safari",
+      "path" : "\/System\/Cryptexes\/App\/System\/Applications\/Safari.app"
+    },
+    {
+      "bundleIdentifier" : "com.example.Foo",
+      "id" : "com.example.Foo#\/Users\/alex\/Applications\/Foo.app",
+      "name" : "Foo",
+      "path" : "\/Users\/alex\/Applications\/Foo.app"
+    }
+  ],
+  "exportedAt" : "2026-08-13T04:12:00Z",
+  "grid" : {
+    "columns" : 6,
+    "pageCapacity" : 24,
+    "preset" : "6x4-128",
+    "rows" : 4
+  },
+  "hidden" : [
+    "com.apple.Chess"
+  ],
+  "items" : [
+    {
+      "id" : "com.apple.Safari",
+      "type" : "app"
+    },
+    {
+      "apps" : [
+        "com.apple.dt.Xcode",
+        "com.microsoft.VSCode"
+      ],
+      "id" : "folder-550e8400-e29b-41d4-a716-446655440000",
+      "name" : "开发",
+      "type" : "folder"
+    },
+    {
+      "id" : "com.apple.Preview",
+      "type" : "app"
+    }
+  ],
+  "kind" : "qlaunchpad.layout",
+  "schemaVersion" : 1
+}

--- a/Tests/QLaunchpadCoreTests/Fixtures/persist-folders.json
+++ b/Tests/QLaunchpadCoreTests/Fixtures/persist-folders.json
@@ -1,0 +1,1 @@
+[{"id":"folder-550e8400-e29b-41d4-a716-446655440000","name":"开发","appIDs":["com.apple.dt.Xcode","com.microsoft.VSCode"]}]

--- a/Tests/QLaunchpadCoreTests/LaunchpadCLIInvocationTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadCLIInvocationTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import QLaunchpadCore
+
+final class LaunchpadCLIInvocationTests: XCTestCase {
+    func testIsInvocationRequiresCommandOrCLIFlag() {
+        XCTAssertFalse(LaunchpadCLIInvocation.isInvocation([]))
+        XCTAssertFalse(LaunchpadCLIInvocation.isInvocation(["--out", "x.json"]))
+        XCTAssertTrue(LaunchpadCLIInvocation.isInvocation(["export"]))
+        XCTAssertTrue(LaunchpadCLIInvocation.isInvocation(["import"]))
+        XCTAssertTrue(LaunchpadCLIInvocation.isInvocation(["validate"]))
+        XCTAssertTrue(LaunchpadCLIInvocation.isInvocation(["help"]))
+        XCTAssertTrue(LaunchpadCLIInvocation.isInvocation(["-h"]))
+        XCTAssertTrue(LaunchpadCLIInvocation.isInvocation(["--help"]))
+        XCTAssertTrue(LaunchpadCLIInvocation.isInvocation(["--cli"]))
+        XCTAssertTrue(LaunchpadCLIInvocation.isInvocation(["--out", "x.json", "--cli"]))
+    }
+
+    func testParseMergeAndReplaceAreExclusive() {
+        XCTAssertThrowsError(
+            try LaunchpadCLIInvocation.parse(["import", "--merge", "--replace"])
+        ) { error in
+            guard case LaunchpadCLIInvocation.ParseError.usage(let message) = error else {
+                return XCTFail("expected usage, got \(error)")
+            }
+            XCTAssertTrue(message.contains("--merge"))
+        }
+    }
+
+    func testParsePrettyAndCompactAreExclusive() {
+        XCTAssertThrowsError(
+            try LaunchpadCLIInvocation.parse(["export", "--pretty", "--compact"])
+        ) { error in
+            guard case LaunchpadCLIInvocation.ParseError.usage(let message) = error else {
+                return XCTFail("expected usage, got \(error)")
+            }
+            XCTAssertTrue(message.contains("--pretty"))
+        }
+    }
+
+    func testParseDefaultsToMergeAndStripsCLIFlag() throws {
+        let parsed = try LaunchpadCLIInvocation.parse(["--cli", "import", "--in", "-"])
+        XCTAssertEqual(parsed.command, "import")
+        XCTAssertEqual(parsed.options.input, "-")
+        XCTAssertFalse(parsed.options.replace)
+        XCTAssertFalse(parsed.options.merge)
+    }
+
+    func testShouldPrettyTTYVersusPipeAndFile() throws {
+        XCTAssertTrue(
+            try LaunchpadCLIInvocation.shouldPretty(
+                pretty: false,
+                compact: false,
+                writingToStdout: true,
+                stdoutIsTTY: true
+            )
+        )
+        XCTAssertFalse(
+            try LaunchpadCLIInvocation.shouldPretty(
+                pretty: false,
+                compact: false,
+                writingToStdout: true,
+                stdoutIsTTY: false
+            )
+        )
+        XCTAssertTrue(
+            try LaunchpadCLIInvocation.shouldPretty(
+                pretty: false,
+                compact: false,
+                writingToStdout: false,
+                stdoutIsTTY: false
+            )
+        )
+        XCTAssertTrue(
+            try LaunchpadCLIInvocation.shouldPretty(
+                pretty: true,
+                compact: false,
+                writingToStdout: true,
+                stdoutIsTTY: false
+            )
+        )
+        XCTAssertFalse(
+            try LaunchpadCLIInvocation.shouldPretty(
+                pretty: false,
+                compact: true,
+                writingToStdout: true,
+                stdoutIsTTY: true
+            )
+        )
+        XCTAssertThrowsError(
+            try LaunchpadCLIInvocation.shouldPretty(
+                pretty: true,
+                compact: true,
+                writingToStdout: true,
+                stdoutIsTTY: true
+            )
+        )
+    }
+
+    func testResolveDomainFailClosedAndPrecedence() throws {
+        XCTAssertEqual(
+            try LaunchpadCLIInvocation.resolveDomain(
+                explicitDomain: "com.example.explicit",
+                appIdentifier: "com.from.app",
+                dev: true,
+                bundledIdentifier: LaunchpadCLIInvocation.releaseDomain
+            ),
+            "com.example.explicit"
+        )
+        XCTAssertEqual(
+            try LaunchpadCLIInvocation.resolveDomain(
+                explicitDomain: nil,
+                appIdentifier: "com.from.app",
+                dev: true,
+                bundledIdentifier: LaunchpadCLIInvocation.releaseDomain
+            ),
+            "com.from.app"
+        )
+        XCTAssertEqual(
+            try LaunchpadCLIInvocation.resolveDomain(
+                explicitDomain: nil,
+                appIdentifier: nil,
+                dev: true,
+                bundledIdentifier: LaunchpadCLIInvocation.releaseDomain
+            ),
+            LaunchpadCLIInvocation.developmentDomain
+        )
+        XCTAssertEqual(
+            try LaunchpadCLIInvocation.resolveDomain(
+                explicitDomain: nil,
+                appIdentifier: nil,
+                dev: false,
+                bundledIdentifier: LaunchpadCLIInvocation.releaseDomain
+            ),
+            LaunchpadCLIInvocation.releaseDomain
+        )
+        XCTAssertEqual(
+            try LaunchpadCLIInvocation.resolveDomain(
+                explicitDomain: nil,
+                appIdentifier: nil,
+                dev: false,
+                bundledIdentifier: LaunchpadCLIInvocation.developmentDomain
+            ),
+            LaunchpadCLIInvocation.developmentDomain
+        )
+        XCTAssertThrowsError(
+            try LaunchpadCLIInvocation.resolveDomain(
+                explicitDomain: nil,
+                appIdentifier: nil,
+                dev: false,
+                bundledIdentifier: nil
+            )
+        )
+        XCTAssertThrowsError(
+            try LaunchpadCLIInvocation.resolveDomain(
+                explicitDomain: nil,
+                appIdentifier: nil,
+                dev: false,
+                bundledIdentifier: "org.swift.swiftpm"
+            )
+        ) { error in
+            guard case LaunchpadCLIInvocation.ParseError.usage = error else {
+                return XCTFail("naked binary must not default to Release, got \(error)")
+            }
+        }
+    }
+
+    func testDecodePersistedFoldersEmptyVersusCorrupt() throws {
+        XCTAssertEqual(try LaunchpadPreferenceStore.decodePersistedFolders(Data()), [])
+        XCTAssertThrowsError(
+            try LaunchpadPreferenceStore.decodePersistedFolders(Data("not-folders".utf8))
+        )
+        let encoded = try LaunchpadPreferenceStore.encodeFolders([
+            AppFolder(id: "folder-a", name: "A", appIDs: ["com.alpha"])
+        ])
+        XCTAssertEqual(try LaunchpadPreferenceStore.decodePersistedFolders(encoded).count, 1)
+    }
+}

--- a/Tests/QLaunchpadCoreTests/LaunchpadCLIProcessTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadCLIProcessTests.swift
@@ -1,0 +1,160 @@
+import CoreFoundation
+import XCTest
+@testable import QLaunchpadCore
+
+final class LaunchpadCLIProcessTests: XCTestCase {
+    private let dryRunDomain = "com.qzrzz.qlaunchpad.tests.cli-dry-run"
+
+    override func tearDown() {
+        clearLayoutDomain(dryRunDomain)
+        super.tearDown()
+    }
+
+    func testNakedExportExitsUsage() throws {
+        let result = try runCLI(["export"])
+        XCTAssertEqual(result.exitCode, 1)
+        XCTAssertTrue(result.stderr.contains("preference domain is required"))
+    }
+
+    func testMergeReplaceXORExitsUsage() throws {
+        let result = try runCLI(["import", "--merge", "--replace", "--dev"])
+        XCTAssertEqual(result.exitCode, 1)
+        XCTAssertTrue(result.stderr.contains("--merge"))
+    }
+
+    func testPrettyCompactXORExitsUsage() throws {
+        let result = try runCLI(["export", "--pretty", "--compact", "--dev"])
+        XCTAssertEqual(result.exitCode, 1)
+        XCTAssertTrue(result.stderr.contains("--pretty"))
+    }
+
+    func testValidateFixtureSucceeds() throws {
+        let fixture = try XCTUnwrap(canonicalFixtureURL())
+        let result = try runCLI(["validate", "--in", fixture.path])
+        XCTAssertEqual(result.exitCode, 0, result.stderr)
+    }
+
+    func testValidateBadJSONExitsTwo() throws {
+        let result = try runCLI(["validate", "--in", "-"], stdin: #"{"kind":"nope"}"#)
+        XCTAssertEqual(result.exitCode, 2)
+        XCTAssertTrue(result.stderr.contains("invalid layout JSON") || result.stderr.contains("schemaVersion"))
+    }
+
+    func testMissingInputFileExitsThree() throws {
+        let result = try runCLI(["validate", "--in", "/tmp/does-not-exist-qlayout.json"])
+        XCTAssertEqual(result.exitCode, 3)
+        XCTAssertTrue(result.stderr.contains("failed to read"))
+    }
+
+    func testAppWithoutIdentifierExitsFour() throws {
+        let result = try runCLI(["export", "--app", "/Applications"])
+        XCTAssertEqual(result.exitCode, 4)
+        XCTAssertTrue(result.stderr.contains("CFBundleIdentifier"))
+    }
+
+    func testDevPrintsUsingDomainBeforeSchemaFailure() throws {
+        let result = try runCLI(
+            ["import", "--dev", "--dry-run", "--in", "-"],
+            stdin: #"{"kind":"nope"}"#
+        )
+        XCTAssertEqual(result.exitCode, 2)
+        XCTAssertTrue(
+            result.stderr.contains("usingDomain: \(LaunchpadPreferenceStore.developmentDomain)"),
+            result.stderr
+        )
+    }
+
+    func testDryRunDoesNotChangeTargetDomain() throws {
+        let foldersData = try LaunchpadPreferenceStore.encodeFolders([])
+        let original = LaunchpadPersistedLayout(
+            itemOrder: ["com.example.keep-me"],
+            foldersData: foldersData,
+            hiddenIDs: ["com.example.hidden"]
+        )
+        XCTAssertTrue(LaunchpadPreferenceStore.writeLayout(domain: dryRunDomain, original))
+
+        let document = """
+        {
+          "kind": "qlaunchpad.layout",
+          "schemaVersion": 1,
+          "items": []
+        }
+        """
+        let result = try runCLI(
+            ["import", "--domain", dryRunDomain, "--dry-run", "--in", "-"],
+            stdin: document
+        )
+        XCTAssertEqual(result.exitCode, 0, result.stderr)
+        XCTAssertTrue(result.stdout.contains("wouldWriteDomain: \(dryRunDomain)"), result.stdout)
+
+        let read = LaunchpadPreferenceStore.readLayout(domain: dryRunDomain)
+        XCTAssertEqual(read.itemOrder, original.itemOrder)
+        XCTAssertEqual(read.foldersData, original.foldersData)
+        XCTAssertEqual(read.hiddenIDs, original.hiddenIDs)
+    }
+
+    private struct CLIResult {
+        var exitCode: Int32
+        var stdout: String
+        var stderr: String
+    }
+
+    private func runCLI(_ arguments: [String], stdin: String? = nil) throws -> CLIResult {
+        let binary = try qlaunchpadBinary()
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = arguments
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        if let stdin {
+            let input = Pipe()
+            process.standardInput = input
+            input.fileHandleForWriting.write(Data(stdin.utf8))
+            try input.fileHandleForWriting.close()
+        }
+        try process.run()
+        process.waitUntilExit()
+        let out = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let err = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return CLIResult(exitCode: process.terminationStatus, stdout: out, stderr: err)
+    }
+
+    private func qlaunchpadBinary() throws -> URL {
+        let fileManager = FileManager.default
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            let candidate = bundle.bundleURL.deletingLastPathComponent().appendingPathComponent("QLaunchpad")
+            if fileManager.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let fallbacks = [
+            root.appendingPathComponent(".build/debug/QLaunchpad"),
+            root.appendingPathComponent(".build/arm64-apple-macosx/debug/QLaunchpad")
+        ]
+        if let found = fallbacks.first(where: { fileManager.isExecutableFile(atPath: $0.path) }) {
+            return found
+        }
+        throw XCTSkip("QLaunchpad binary not found next to tests")
+    }
+
+    private func canonicalFixtureURL() -> URL? {
+        Bundle.module.url(forResource: "canonical-layout", withExtension: "json")
+    }
+
+    private func clearLayoutDomain(_ domain: String) {
+        let applicationID = domain as CFString
+        CFPreferencesSetAppValue(LaunchpadPersistence.itemOrderKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.foldersKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.hiddenAppsKey as CFString, nil, applicationID)
+        CFPreferencesAppSynchronize(applicationID)
+        let plist = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Preferences/\(domain).plist")
+        try? FileManager.default.removeItem(at: plist)
+    }
+}

--- a/Tests/QLaunchpadCoreTests/LaunchpadLayoutTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadLayoutTests.swift
@@ -271,6 +271,81 @@ final class LaunchpadLayoutTests: XCTestCase {
         XCTAssertEqual(folders.first?.appIDs, ["com.apple.dt.Xcode", "com.microsoft.VSCode"])
     }
 
+    func testDecodeFoldersAcceptsHistoricalJSONEncoderPayload() throws {
+        let historical = Data(
+            #"[{"id":"folder-550e8400-e29b-41d4-a716-446655440000","appIDs":["com.example.Foo#\/Users\/alex\/Applications\/Foo.app"],"name":"开发"}]"#.utf8
+        )
+        let folders = try LaunchpadPersistence.decodeFolders(historical)
+        XCTAssertEqual(folders.map(\.id), ["folder-550e8400-e29b-41d4-a716-446655440000"])
+        XCTAssertEqual(folders.first?.name, "开发")
+        XCTAssertEqual(
+            folders.first?.appIDs,
+            ["com.example.Foo#/Users/alex/Applications/Foo.app"]
+        )
+    }
+
+    func testTrimmedFolderIDsAreUnique() {
+        let document = LaunchpadLayoutDocument(items: [
+            .folder(id: "folder-a", name: "A", apps: ["com.alpha"]),
+            .folder(id: " folder-a", name: "B", apps: ["com.bravo"])
+        ])
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: document,
+                mode: .merge,
+                strict: false,
+                scanned: known(
+                    ("com.alpha", "Alpha", "/A/Alpha.app"),
+                    ("com.bravo", "Bravo", "/B/Bravo.app")
+                ),
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .duplicateID("folder-a"))
+        }
+    }
+
+    func testFolderIDCollidingWithLeftoverScannedAppRejected() {
+        let document = LaunchpadLayoutDocument(items: [
+            .folder(id: "folder-collide", name: "X", apps: ["com.alpha"])
+        ])
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: document,
+                mode: .merge,
+                strict: false,
+                scanned: known(
+                    ("com.alpha", "Alpha", "/A/Alpha.app"),
+                    ("folder-collide", "Collide", "/C/Collide.app")
+                ),
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .duplicateID("folder-collide"))
+        }
+    }
+
+    func testResolvedIDAliasesRejectedAsDuplicate() {
+        let scanned = known(
+            ("com.example.Foo", "Foo", "/Users/alex/Applications/Foo.app")
+        )
+        let document = LaunchpadLayoutDocument(items: [
+            .app(id: "com.example.Foo"),
+            .app(id: "com.example.Foo#/Users/alex/Applications/Foo.app")
+        ])
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: document,
+                mode: .merge,
+                strict: false,
+                scanned: scanned,
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .duplicateID("com.example.Foo"))
+        }
+    }
+
     private func known(_ items: (String, String, String)...) -> [LaunchpadKnownApp] {
         items
             .map { LaunchpadKnownApp(id: $0.0, bundleIdentifier: $0.0, name: $0.1, path: $0.2) }

--- a/Tests/QLaunchpadCoreTests/LaunchpadLayoutTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadLayoutTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+@testable import QLaunchpadCore
+
+final class LaunchpadLayoutTests: XCTestCase {
+    func testEmptyFolderDropped() {
+        let apps = known(
+            ("com.alpha", "Alpha", "/A/Alpha.app"),
+            ("com.bravo", "Bravo", "/A/Bravo.app")
+        )
+        let folders = [
+            AppFolder(id: "folder-empty", name: "Empty", appIDs: []),
+            AppFolder(id: "folder-keep", name: "Keep", appIDs: ["com.alpha"])
+        ]
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: apps,
+            folders: folders,
+            order: ["folder-empty", "com.bravo", "folder-keep"],
+            hidden: []
+        )
+        XCTAssertEqual(result.folders.map(\.id), ["folder-keep"])
+        XCTAssertEqual(result.order, ["com.bravo", "folder-keep"])
+    }
+
+    func testHiddenMembersStrippedFromFolderAndOrder() {
+        let apps = known(
+            ("com.alpha", "Alpha", "/A/Alpha.app"),
+            ("com.bravo", "Bravo", "/A/Bravo.app"),
+            ("com.charlie", "Charlie", "/A/Charlie.app")
+        )
+        let folders = [
+            AppFolder(id: "folder-dev", name: "Dev", appIDs: ["com.alpha", "com.bravo"])
+        ]
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: apps,
+            folders: folders,
+            order: ["folder-dev", "com.charlie", "com.bravo"],
+            hidden: ["com.bravo"]
+        )
+        XCTAssertEqual(result.folders.map(\.appIDs), [["com.alpha"]])
+        XCTAssertEqual(result.order, ["folder-dev", "com.charlie"])
+        XCTAssertFalse(result.order.contains("com.bravo"))
+    }
+
+    func testDuplicateAppKeepsFirstFolder() {
+        let apps = known(
+            ("com.alpha", "Alpha", "/A/Alpha.app"),
+            ("com.bravo", "Bravo", "/A/Bravo.app")
+        )
+        let folders = [
+            AppFolder(id: "folder-a", name: "A", appIDs: ["com.alpha"]),
+            AppFolder(id: "folder-b", name: "B", appIDs: ["com.alpha", "com.bravo"])
+        ]
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: apps,
+            folders: folders,
+            order: ["folder-a", "folder-b"],
+            hidden: []
+        )
+        XCTAssertEqual(result.folders.map(\.id), ["folder-a", "folder-b"])
+        XCTAssertEqual(result.folders[0].appIDs, ["com.alpha"])
+        XCTAssertEqual(result.folders[1].appIDs, ["com.bravo"])
+    }
+
+    func testLeftoverAppendOrderAndMissingFolderBeforeLeftoverApps() {
+        let apps = known(
+            ("com.zebra", "Zebra", "/Z/Zebra.app"),
+            ("com.apple.b", "Apple", "/B/Apple.app"),
+            ("com.apple.a", "Apple", "/A/Apple.app"),
+            ("com.kept", "Kept", "/K/Kept.app")
+        )
+        let folders = [
+            AppFolder(id: "folder-late", name: "Late", appIDs: ["com.kept"])
+        ]
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: apps,
+            folders: folders,
+            order: ["com.zebra"],
+            hidden: []
+        )
+        XCTAssertEqual(
+            result.order,
+            ["com.zebra", "folder-late", "com.apple.a", "com.apple.b"]
+        )
+    }
+
+    func testItemsHiddenOverlapRejected() {
+        let document = LaunchpadLayoutDocument(
+            items: [
+                .app(id: "com.apple.Safari"),
+                .folder(id: "folder-dev", name: "开发", apps: ["com.apple.dt.Xcode"])
+            ],
+            hidden: ["com.apple.Safari"]
+        )
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: document,
+                mode: .merge,
+                strict: false,
+                scanned: known(("com.apple.Safari", "Safari", "/S/Safari.app")),
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .itemHiddenOverlap("com.apple.Safari"))
+        }
+
+        let folderOverlap = LaunchpadLayoutDocument(
+            items: [
+                .folder(id: "folder-dev", name: "开发", apps: ["com.apple.dt.Xcode"])
+            ],
+            hidden: ["com.apple.dt.Xcode"]
+        )
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: folderOverlap,
+                mode: .merge,
+                strict: false,
+                scanned: known(("com.apple.dt.Xcode", "Xcode", "/X/Xcode.app")),
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .itemHiddenOverlap("com.apple.dt.Xcode"))
+        }
+    }
+
+    func testCompositeIDResolvesWhenOnlyBareCopyRemains() throws {
+        let scanned = known(
+            ("com.example.Foo", "Foo", "/Users/alex/Applications/Foo.app")
+        )
+        let rawID = "com.example.Foo#/Users/alex/Applications/Foo.app"
+        let resolved = LaunchpadLayoutResolver.resolve(rawID: rawID, scanned: scanned, catalog: nil)
+        XCTAssertEqual(resolved?.id, "com.example.Foo")
+
+        let document = LaunchpadLayoutDocument(items: [.app(id: rawID)])
+        let result = try LaunchpadLayoutImporter.apply(
+            document: document,
+            mode: .merge,
+            strict: true,
+            scanned: scanned,
+            currentHidden: []
+        )
+        XCTAssertEqual(result.layout.order, ["com.example.Foo"])
+        XCTAssertEqual(result.report.resolvedApps, 1)
+        XCTAssertTrue(result.report.skippedUnknown.isEmpty)
+    }
+
+    func testReplaceHidesLeftoversBeforeReconcile() throws {
+        let scanned = known(
+            ("com.kept", "Kept", "/K/Kept.app"),
+            ("com.extra", "Extra", "/E/Extra.app")
+        )
+        let document = LaunchpadLayoutDocument(items: [.app(id: "com.kept")])
+        let result = try LaunchpadLayoutImporter.apply(
+            document: document,
+            mode: .replace,
+            strict: false,
+            scanned: scanned,
+            currentHidden: []
+        )
+        XCTAssertEqual(result.layout.order, ["com.kept"])
+        XCTAssertTrue(result.layout.hidden.contains("com.extra"))
+        XCTAssertFalse(result.layout.order.contains("com.extra"))
+        XCTAssertEqual(result.report.newlyHiddenByReplace, ["com.extra"])
+        XCTAssertTrue(result.report.appendedLeftover.isEmpty)
+    }
+
+    func testHiddenOmittedVersusPresentThreeState() throws {
+        let scanned = known(
+            ("com.alpha", "Alpha", "/A/Alpha.app"),
+            ("com.bravo", "Bravo", "/B/Bravo.app"),
+            ("com.hidden", "Hidden", "/H/Hidden.app")
+        )
+        let currentHidden: Set<String> = ["com.hidden"]
+
+        let omitted = try LaunchpadLayoutImporter.apply(
+            document: LaunchpadLayoutDocument(items: [.app(id: "com.alpha")]),
+            mode: .merge,
+            strict: false,
+            scanned: scanned,
+            currentHidden: currentHidden
+        )
+        XCTAssertEqual(omitted.layout.hidden, ["com.hidden"])
+        XCTAssertFalse(omitted.report.hiddenReplaced)
+        XCTAssertEqual(omitted.report.appendedLeftover, ["com.bravo"])
+        XCTAssertTrue(omitted.layout.order.contains("com.bravo"))
+
+        let replaced = try LaunchpadLayoutImporter.apply(
+            document: LaunchpadLayoutDocument(
+                items: [.app(id: "com.alpha")],
+                hidden: ["com.bravo"]
+            ),
+            mode: .merge,
+            strict: false,
+            scanned: scanned,
+            currentHidden: currentHidden
+        )
+        XCTAssertEqual(replaced.layout.hidden, ["com.bravo"])
+        XCTAssertTrue(replaced.report.hiddenReplaced)
+        XCTAssertTrue(replaced.layout.order.contains("com.hidden"))
+        XCTAssertFalse(replaced.layout.order.contains("com.bravo"))
+
+        let emptied = try LaunchpadLayoutImporter.apply(
+            document: LaunchpadLayoutDocument(
+                items: [.app(id: "com.alpha")],
+                hidden: []
+            ),
+            mode: .merge,
+            strict: false,
+            scanned: scanned,
+            currentHidden: currentHidden
+        )
+        XCTAssertTrue(emptied.layout.hidden.isEmpty)
+        XCTAssertTrue(emptied.report.hiddenReplaced)
+        XCTAssertEqual(Set(emptied.layout.order), ["com.alpha", "com.bravo", "com.hidden"])
+    }
+
+    func testOmittedHiddenUnhidesClaimedID() throws {
+        let scanned = known(
+            ("com.chess", "Chess", "/C/Chess.app"),
+            ("com.preview", "Preview", "/P/Preview.app")
+        )
+        let result = try LaunchpadLayoutImporter.apply(
+            document: LaunchpadLayoutDocument(items: [.app(id: "com.chess")]),
+            mode: .merge,
+            strict: false,
+            scanned: scanned,
+            currentHidden: ["com.chess"]
+        )
+        XCTAssertEqual(result.layout.order.first, "com.chess")
+        XCTAssertEqual(result.report.unhiddenByClaim, ["com.chess"])
+        XCTAssertFalse(result.layout.hidden.contains("com.chess"))
+        XCTAssertTrue(result.report.appendedLeftover.contains("com.preview"))
+    }
+
+    func testCanonicalLayoutFixtureRoundTrip() throws {
+        let fixture = try fixtureData("canonical-layout")
+        let document = try LaunchpadLayoutDocument.makeDecoder()
+            .decode(LaunchpadLayoutDocument.self, from: fixture)
+        let encoded = try LaunchpadLayoutDocument.makeEncoder(pretty: true).encode(document)
+        XCTAssertEqual(
+            String(data: encoded, encoding: .utf8),
+            String(data: fixture, encoding: .utf8)
+        )
+
+        XCTAssertEqual(document.kind, LaunchpadLayoutKind.current)
+        XCTAssertEqual(document.schemaVersion, 1)
+        XCTAssertEqual(document.appVersion, "1.0.0")
+        XCTAssertEqual(document.hidden, ["com.apple.Chess"])
+        XCTAssertEqual(document.items, [
+            .app(id: "com.apple.Safari"),
+            .folder(
+                id: "folder-550e8400-e29b-41d4-a716-446655440000",
+                name: "开发",
+                apps: ["com.apple.dt.Xcode", "com.microsoft.VSCode"]
+            ),
+            .app(id: "com.apple.Preview")
+        ])
+    }
+
+    func testEncodeFoldersMatchesOnDiskFixtureAndDiffersFromLayoutEncoder() throws {
+        let fixture = try fixtureData("persist-folders")
+        let folders = try LaunchpadPersistence.decodeFolders(fixture)
+        let reencoded = try LaunchpadPersistence.encodeFolders(folders)
+        XCTAssertEqual(
+            String(data: reencoded, encoding: .utf8),
+            String(data: fixture, encoding: .utf8)
+        )
+
+        let layoutEncoded = try LaunchpadLayoutDocument.makeEncoder(pretty: true).encode(folders)
+        XCTAssertNotEqual(layoutEncoded, reencoded)
+        XCTAssertEqual(folders.map(\.id), ["folder-550e8400-e29b-41d4-a716-446655440000"])
+        XCTAssertEqual(folders.first?.appIDs, ["com.apple.dt.Xcode", "com.microsoft.VSCode"])
+    }
+
+    private func known(_ items: (String, String, String)...) -> [LaunchpadKnownApp] {
+        items
+            .map { LaunchpadKnownApp(id: $0.0, bundleIdentifier: $0.0, name: $0.1, path: $0.2) }
+            .sorted { lhs, rhs in
+                let nameOrder = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+                if nameOrder != .orderedSame {
+                    return nameOrder == .orderedAscending
+                }
+                return lhs.path < rhs.path
+            }
+    }
+
+    private func fixtureData(_ name: String) throws -> Data {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: "json"))
+        return try Data(contentsOf: url)
+    }
+}

--- a/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
@@ -19,12 +19,14 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
             )
         ]
         let foldersData = try LaunchpadPreferenceStore.encodeFolders(folders)
-        LaunchpadPreferenceStore.writeLayout(
-            domain: domain,
-            LaunchpadPersistedLayout(
-                itemOrder: ["folder-550e8400-e29b-41d4-a716-446655440000", "com.apple.Safari"],
-                foldersData: foldersData,
-                hiddenIDs: ["com.zebra", "com.alpha"]
+        XCTAssertTrue(
+            LaunchpadPreferenceStore.writeLayout(
+                domain: domain,
+                LaunchpadPersistedLayout(
+                    itemOrder: ["folder-550e8400-e29b-41d4-a716-446655440000", "com.apple.Safari"],
+                    foldersData: foldersData,
+                    hiddenIDs: ["com.zebra", "com.alpha"]
+                )
             )
         )
 

--- a/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
@@ -1,0 +1,152 @@
+import CoreFoundation
+import XCTest
+@testable import QLaunchpadCore
+
+final class LaunchpadPreferenceStoreTests: XCTestCase {
+    private let domain = "com.qzrzz.qlaunchpad.tests.preference-store"
+
+    override func tearDown() {
+        clearLayoutDomain(domain)
+        super.tearDown()
+    }
+
+    func testWriteLayoutStoresCFArrayAndCFDataAndSortsHidden() throws {
+        let folders = [
+            AppFolder(
+                id: "folder-550e8400-e29b-41d4-a716-446655440000",
+                name: "开发",
+                appIDs: ["com.apple.dt.Xcode", "com.microsoft.VSCode"]
+            )
+        ]
+        let foldersData = try LaunchpadPreferenceStore.encodeFolders(folders)
+        LaunchpadPreferenceStore.writeLayout(
+            domain: domain,
+            LaunchpadPersistedLayout(
+                itemOrder: ["folder-550e8400-e29b-41d4-a716-446655440000", "com.apple.Safari"],
+                foldersData: foldersData,
+                hiddenIDs: ["com.zebra", "com.alpha"]
+            )
+        )
+
+        let read = LaunchpadPreferenceStore.readLayout(domain: domain)
+        XCTAssertEqual(
+            read.itemOrder,
+            ["folder-550e8400-e29b-41d4-a716-446655440000", "com.apple.Safari"]
+        )
+        XCTAssertEqual(read.foldersData, foldersData)
+        XCTAssertEqual(read.hiddenIDs, ["com.alpha", "com.zebra"])
+        XCTAssertEqual(try LaunchpadPreferenceStore.decodeFolders(read.foldersData), folders)
+
+        CFPreferencesAppSynchronize(domain as CFString)
+        let rawFolders = CFPreferencesCopyAppValue(
+            LaunchpadPersistence.foldersKey as CFString,
+            domain as CFString
+        )
+        XCTAssertTrue(rawFolders is Data)
+        XCTAssertFalse(rawFolders is String)
+
+        let rawOrder = CFPreferencesCopyAppValue(
+            LaunchpadPersistence.itemOrderKey as CFString,
+            domain as CFString
+        )
+        XCTAssertEqual(rawOrder as? [String], read.itemOrder)
+    }
+
+    func testPersistIfChangedLeavesIdenticalLayoutUntouched() throws {
+        let folders = [AppFolder(id: "folder-a", name: "A", appIDs: ["com.alpha"])]
+        let foldersData = try LaunchpadPreferenceStore.encodeFolders(folders)
+        let layout = LaunchpadPersistedLayout(
+            itemOrder: ["folder-a"],
+            foldersData: foldersData,
+            hiddenIDs: ["com.hidden"]
+        )
+        LaunchpadPreferenceStore.writeLayout(domain: domain, layout)
+        LaunchpadPreferenceStore.writeLayout(domain: domain, layout)
+
+        let read = LaunchpadPreferenceStore.readLayout(domain: domain)
+        XCTAssertEqual(read.itemOrder, ["folder-a"])
+        XCTAssertEqual(read.foldersData, foldersData)
+        XCTAssertEqual(read.hiddenIDs, ["com.hidden"])
+    }
+
+    func testReadStringAndStringArraySynchronizeFirst() {
+        CFPreferencesSetAppValue(
+            LaunchpadPersistence.gridLayoutPresetKey as CFString,
+            "7x5-128" as CFString,
+            domain as CFString
+        )
+        CFPreferencesSetAppValue(
+            LaunchpadPersistence.customSourcesKey as CFString,
+            ["/tmp/Extra Apps"] as CFArray,
+            domain as CFString
+        )
+        CFPreferencesAppSynchronize(domain as CFString)
+
+        XCTAssertEqual(
+            LaunchpadPreferenceStore.readString(
+                domain: domain,
+                key: LaunchpadPersistence.gridLayoutPresetKey
+            ),
+            "7x5-128"
+        )
+        XCTAssertEqual(
+            LaunchpadPreferenceStore.readStringArray(
+                domain: domain,
+                key: LaunchpadPersistence.customSourcesKey
+            ),
+            ["/tmp/Extra Apps"]
+        )
+    }
+
+    func testMissingLayoutKeysAreEmpty() {
+        let read = LaunchpadPreferenceStore.readLayout(domain: domain)
+        XCTAssertEqual(read.itemOrder, [])
+        XCTAssertEqual(read.foldersData, Data())
+        XCTAssertEqual(read.hiddenIDs, [])
+        XCTAssertNil(
+            LaunchpadPreferenceStore.readString(
+                domain: domain,
+                key: LaunchpadPersistence.gridLayoutPresetKey
+            )
+        )
+        XCTAssertEqual(
+            LaunchpadPreferenceStore.readStringArray(
+                domain: domain,
+                key: LaunchpadPersistence.customSourcesKey
+            ),
+            []
+        )
+    }
+
+    func testBackupURLSplitsReleaseAndDevDomains() {
+        let release = LaunchpadPreferenceStore.layoutBackupFileURL(
+            domain: LaunchpadPreferenceStore.releaseDomain
+        )
+        let development = LaunchpadPreferenceStore.layoutBackupFileURL(
+            domain: LaunchpadPreferenceStore.developmentDomain
+        )
+        XCTAssertTrue(release.path.hasSuffix("Application Support/QLaunch/layout.backup.json"))
+        XCTAssertTrue(development.path.hasSuffix("Application Support/QLaunch Dev/layout.backup.json"))
+        XCTAssertNotEqual(release, development)
+    }
+
+    func testEncodeFoldersWrapperMatchesPersistenceEncoder() throws {
+        let folders = [
+            AppFolder(id: "folder-1", name: "开发", appIDs: ["com.example.Foo#/Users/alex/Applications/Foo.app"])
+        ]
+        XCTAssertEqual(
+            try LaunchpadPreferenceStore.encodeFolders(folders),
+            try LaunchpadPersistence.encodeFolders(folders)
+        )
+    }
+
+    private func clearLayoutDomain(_ domain: String) {
+        let applicationID = domain as CFString
+        CFPreferencesSetAppValue(LaunchpadPersistence.itemOrderKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.foldersKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.hiddenAppsKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.gridLayoutPresetKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.customSourcesKey as CFString, nil, applicationID)
+        CFPreferencesAppSynchronize(applicationID)
+    }
+}

--- a/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
@@ -52,7 +52,7 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
         XCTAssertEqual(rawOrder as? [String], read.itemOrder)
     }
 
-    func testPersistIfChangedLeavesIdenticalLayoutUntouched() throws {
+    func testPersistIfChangedSkipsSecondWrite() throws {
         let folders = [AppFolder(id: "folder-a", name: "A", appIDs: ["com.alpha"])]
         let foldersData = try LaunchpadPreferenceStore.encodeFolders(folders)
         let layout = LaunchpadPersistedLayout(
@@ -61,7 +61,26 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
             hiddenIDs: ["com.hidden"]
         )
         LaunchpadPreferenceStore.writeLayout(domain: domain, layout)
+
+        let probeKey = "layoutWriteProbe"
+        CFPreferencesSetAppValue(probeKey as CFString, "keep" as CFString, domain as CFString)
+        CFPreferencesAppSynchronize(domain as CFString)
+
+        let plistURL = preferencesPlistURL(domain)
+        let firstModified = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: plistURL.path)[.modificationDate] as? Date
+        )
+
         LaunchpadPreferenceStore.writeLayout(domain: domain, layout)
+
+        let secondModified = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: plistURL.path)[.modificationDate] as? Date
+        )
+        XCTAssertEqual(firstModified, secondModified)
+        XCTAssertEqual(
+            CFPreferencesCopyAppValue(probeKey as CFString, domain as CFString) as? String,
+            "keep"
+        )
 
         let read = LaunchpadPreferenceStore.readLayout(domain: domain)
         XCTAssertEqual(read.itemOrder, ["folder-a"])
@@ -69,7 +88,7 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
         XCTAssertEqual(read.hiddenIDs, ["com.hidden"])
     }
 
-    func testReadStringAndStringArraySynchronizeFirst() {
+    func testReadStringAndStringArray() {
         CFPreferencesSetAppValue(
             LaunchpadPersistence.gridLayoutPresetKey as CFString,
             "7x5-128" as CFString,
@@ -140,6 +159,11 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
         )
     }
 
+    private func preferencesPlistURL(_ domain: String) -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Preferences/\(domain).plist")
+    }
+
     private func clearLayoutDomain(_ domain: String) {
         let applicationID = domain as CFString
         CFPreferencesSetAppValue(LaunchpadPersistence.itemOrderKey as CFString, nil, applicationID)
@@ -147,6 +171,8 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
         CFPreferencesSetAppValue(LaunchpadPersistence.hiddenAppsKey as CFString, nil, applicationID)
         CFPreferencesSetAppValue(LaunchpadPersistence.gridLayoutPresetKey as CFString, nil, applicationID)
         CFPreferencesSetAppValue(LaunchpadPersistence.customSourcesKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue("layoutWriteProbe" as CFString, nil, applicationID)
         CFPreferencesAppSynchronize(applicationID)
+        try? FileManager.default.removeItem(at: preferencesPlistURL(domain))
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "release": "bun scripts/release.ts",
     "run": "bun scripts/dev.ts",
     "clean": "bun scripts/clean.ts",
-    "check": "SWIFT_MODULECACHE_PATH=/private/tmp/qlaunchpad-swift-module-cache CLANG_MODULE_CACHE_PATH=/private/tmp/qlaunchpad-clang-module-cache swift package describe"
+    "check": "SWIFT_MODULECACHE_PATH=/private/tmp/qlaunchpad-swift-module-cache CLANG_MODULE_CACHE_PATH=/private/tmp/qlaunchpad-clang-module-cache swift package describe",
+    "layout:export": "bun scripts/layout.ts export",
+    "layout:import": "bun scripts/layout.ts import",
+    "layout:validate": "bun scripts/layout.ts validate"
   }
 }

--- a/scripts/layout.ts
+++ b/scripts/layout.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env bun
+
+/**
+ * Locate a packaged QLaunchpad binary and spawn a *new* CLI process.
+ * Never `swift run`, never `open -a`, never send argv to a live GUI.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+
+const DEV_EXECUTABLE_SUFFIX = "/QLaunch Dev.app/Contents/MacOS/QLaunchpad";
+const RELEASE_EXECUTABLE_SUFFIX = "/QLaunch.app/Contents/MacOS/QLaunchpad";
+
+const DEBUG_APP = join("build/DerivedData/Build/Products/Debug", "QLaunch Dev.app");
+const RELEASE_APP = join("build/DerivedData/Build/Products/Release", "QLaunch.app");
+const APPLICATIONS_APP = "/Applications/QLaunch.app";
+
+const DEBUG_EXECUTABLE = join(ROOT, DEBUG_APP, "Contents/MacOS/QLaunchpad");
+const RELEASE_EXECUTABLE = join(ROOT, RELEASE_APP, "Contents/MacOS/QLaunchpad");
+const APPLICATIONS_EXECUTABLE = join(APPLICATIONS_APP, "Contents/MacOS/QLaunchpad");
+
+const CLI_COMMANDS = new Set(["export", "import", "validate", "help", "-h", "--help"]);
+
+function extractExecutable(line: string, marker: string): string | null {
+  const index = line.indexOf(marker);
+  if (index === -1) return null;
+  if (/\bpgrep\b/.test(line)) return null;
+  let start = index;
+  while (start > 0 && line[start - 1] !== " ") {
+    start -= 1;
+  }
+  return line.slice(start, index + marker.length);
+}
+
+function findRunning(marker: string): string | null {
+  const result = Bun.spawnSync(["pgrep", "-lf", marker], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) return null;
+  const text = new TextDecoder().decode(result.stdout);
+  for (const line of text.split("\n")) {
+    const path = extractExecutable(line, marker);
+    if (path && existsSync(path)) return path;
+  }
+  return null;
+}
+
+function resolvePackagedBinary():
+  | { ok: true; path: string }
+  | { ok: false; runningDev: string | null; runningRelease: string | null } {
+  const runningDev = findRunning(DEV_EXECUTABLE_SUFFIX);
+  if (runningDev) return { ok: true, path: runningDev };
+
+  const runningRelease = findRunning(RELEASE_EXECUTABLE_SUFFIX);
+  if (runningRelease) return { ok: true, path: runningRelease };
+
+  if (existsSync(DEBUG_EXECUTABLE)) return { ok: true, path: DEBUG_EXECUTABLE };
+  if (existsSync(RELEASE_EXECUTABLE)) return { ok: true, path: RELEASE_EXECUTABLE };
+  if (existsSync(APPLICATIONS_EXECUTABLE)) return { ok: true, path: APPLICATIONS_EXECUTABLE };
+
+  return { ok: false, runningDev, runningRelease };
+}
+
+function printMissingBinary(
+  runningDev: string | null,
+  runningRelease: string | null,
+): void {
+  console.error("未找到 QLaunch Dev.app / QLaunch.app。");
+  console.error("已探测:");
+  console.error(
+    "  (running) " + (runningDev ?? "…/QLaunch Dev.app/Contents/MacOS/QLaunchpad"),
+  );
+  console.error(
+    "  (running) " + (runningRelease ?? "…/QLaunch.app/Contents/MacOS/QLaunchpad"),
+  );
+  console.error("  " + DEBUG_APP);
+  console.error("  " + RELEASE_APP);
+  console.error("  " + APPLICATIONS_APP);
+  console.error("请先 bun run dev");
+}
+
+function printUsage(): void {
+  console.log(`Usage:
+  bun run layout:export -- [--out <path>|-] [--pretty|--compact] [--no-catalog] [--no-paths]
+  bun run layout:import -- [--in <path>|-] [--merge|--replace] [--strict] [--dry-run]
+  bun run layout:validate -- [--in <path>|-]
+
+Spawns a new packaged QLaunchpad process (QLaunch Dev.app / QLaunch.app).
+Does not call swift run, open -a, or send arguments to a running GUI.
+`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const command = args.find((arg) => CLI_COMMANDS.has(arg));
+  if (command == null) {
+    console.error("error: missing export|import|validate command");
+    printUsage();
+    process.exit(1);
+  }
+  if (
+    (command === "help" || command === "-h" || command === "--help") &&
+    args.every((arg) => CLI_COMMANDS.has(arg) || arg === "--cli")
+  ) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const resolved = resolvePackagedBinary();
+  if (!resolved.ok) {
+    printMissingBinary(resolved.runningDev, resolved.runningRelease);
+    process.exit(1);
+  }
+
+  const child = Bun.spawn([resolved.path, ...args], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const code = await child.exited;
+  process.exit(code ?? 1);
+}
+
+main().catch((error) => {
+  console.error("✗ " + (error instanceof Error ? error.message : error));
+  process.exit(1);
+});

--- a/scripts/layout.ts
+++ b/scripts/layout.ts
@@ -6,9 +6,9 @@
  */
 
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
-const ROOT = join(import.meta.dir, "..");
+const ROOT = resolve(join(import.meta.dir, ".."));
 
 const DEV_EXECUTABLE_SUFFIX = "/QLaunch Dev.app/Contents/MacOS/QLaunchpad";
 const RELEASE_EXECUTABLE_SUFFIX = "/QLaunch.app/Contents/MacOS/QLaunchpad";
@@ -23,15 +23,21 @@ const APPLICATIONS_EXECUTABLE = join(APPLICATIONS_APP, "Contents/MacOS/QLaunchpa
 
 const CLI_COMMANDS = new Set(["export", "import", "validate", "help", "-h", "--help"]);
 
-function extractExecutable(line: string, marker: string): string | null {
-  const index = line.indexOf(marker);
-  if (index === -1) return null;
+export function extractExecutable(line: string, marker: string): string | null {
   if (/\bpgrep\b/.test(line)) return null;
-  let start = index;
-  while (start > 0 && line[start - 1] !== " ") {
-    start -= 1;
-  }
-  return line.slice(start, index + marker.length);
+  const match = line.match(/^\s*\d+\s+(.*)$/);
+  if (match == null) return null;
+  const command = match[1] ?? "";
+  const index = command.indexOf(marker);
+  if (index === -1) return null;
+  const slash = command.indexOf("/");
+  if (slash === -1 || slash > index) return null;
+  return command.slice(slash, index + marker.length);
+}
+
+function isUnderRoot(path: string): boolean {
+  const resolved = resolve(path);
+  return resolved === ROOT || resolved.startsWith(ROOT + "/");
 }
 
 function findRunning(marker: string): string | null {
@@ -52,16 +58,43 @@ function resolvePackagedBinary():
   | { ok: true; path: string }
   | { ok: false; runningDev: string | null; runningRelease: string | null } {
   const runningDev = findRunning(DEV_EXECUTABLE_SUFFIX);
-  if (runningDev) return { ok: true, path: runningDev };
+  if (runningDev && isUnderRoot(runningDev)) return { ok: true, path: runningDev };
 
   const runningRelease = findRunning(RELEASE_EXECUTABLE_SUFFIX);
-  if (runningRelease) return { ok: true, path: runningRelease };
+  if (runningRelease && isUnderRoot(runningRelease)) return { ok: true, path: runningRelease };
 
   if (existsSync(DEBUG_EXECUTABLE)) return { ok: true, path: DEBUG_EXECUTABLE };
   if (existsSync(RELEASE_EXECUTABLE)) return { ok: true, path: RELEASE_EXECUTABLE };
   if (existsSync(APPLICATIONS_EXECUTABLE)) return { ok: true, path: APPLICATIONS_EXECUTABLE };
 
   return { ok: false, runningDev, runningRelease };
+}
+
+function normalizeCLIArgv(args: string[]):
+  | { ok: true; argv: string[] }
+  | { ok: true; helpOnly: true }
+  | { ok: false; error: string } {
+  const filtered = args.filter((arg) => arg !== "--cli");
+  let command: string | null = null;
+  const rest: string[] = [];
+  for (const arg of filtered) {
+    if (command == null && CLI_COMMANDS.has(arg)) {
+      command = arg;
+      continue;
+    }
+    rest.push(arg);
+  }
+  if (command == null) {
+    return { ok: false, error: "missing export|import|validate command" };
+  }
+  if (
+    (command === "help" || command === "-h" || command === "--help") &&
+    rest.length === 0
+  ) {
+    return { ok: true, helpOnly: true };
+  }
+  // Subcommand is argv[0] after --cli so LaunchpadCLI.isInvocation is true.
+  return { ok: true, argv: ["--cli", command, ...rest] };
 }
 
 function printMissingBinary(
@@ -94,17 +127,13 @@ Does not call swift run, open -a, or send arguments to a running GUI.
 }
 
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  const command = args.find((arg) => CLI_COMMANDS.has(arg));
-  if (command == null) {
-    console.error("error: missing export|import|validate command");
+  const normalized = normalizeCLIArgv(process.argv.slice(2));
+  if (!normalized.ok) {
+    console.error("error: " + normalized.error);
     printUsage();
     process.exit(1);
   }
-  if (
-    (command === "help" || command === "-h" || command === "--help") &&
-    args.every((arg) => CLI_COMMANDS.has(arg) || arg === "--cli")
-  ) {
+  if ("helpOnly" in normalized) {
     printUsage();
     process.exit(0);
   }
@@ -115,7 +144,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const child = Bun.spawn([resolved.path, ...args], {
+  const child = Bun.spawn([resolved.path, ...normalized.argv], {
     stdin: "inherit",
     stdout: "inherit",
     stderr: "inherit",
@@ -124,7 +153,9 @@ async function main(): Promise<void> {
   process.exit(code ?? 1);
 }
 
-main().catch((error) => {
-  console.error("✗ " + (error instanceof Error ? error.message : error));
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("✗ " + (error instanceof Error ? error.message : error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
Headless `export` / `import` / `validate` on the same `QLaunchpad` binary, fail-closed domain resolution, and `bun run layout:*` that only spawns a packaged `.app` binary.

## Test plan
- [ ] `swift test` (includes CLI invocation / exit-code tests)
- [ ] Naked `swift run QLaunchpad export` exits 1 (does not write Release prefs)
- [ ] `bun run layout:export` / `layout:import -- --dry-run --strict`
- [ ] GUI open → CLI import updates the grid without restart