### PR TITLE
Add versioned Launchpad layout JSON model and tested reconciler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,14 +10,27 @@ let package = Package(
         .executable(name: "QLaunchpad", targets: ["QLaunchpad"])
     ],
     targets: [
+        .target(
+            name: "QLaunchpadCore",
+            path: "Sources/QLaunchpadCore"
+        ),
         .executableTarget(
             name: "QLaunchpad",
+            dependencies: ["QLaunchpadCore"],
             path: "Sources/QLaunchpad",
             resources: [
                 .process("Resources")
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v5)
+            ]
+        ),
+        .testTarget(
+            name: "QLaunchpadCoreTests",
+            dependencies: ["QLaunchpadCore"],
+            path: "Tests/QLaunchpadCoreTests",
+            resources: [
+                .process("Fixtures")
             ]
         )
     ]

--- a/Sources/QLaunchpad/AppModel.swift
+++ b/Sources/QLaunchpad/AppModel.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import Foundation
+import QLaunchpadCore
 
 enum QLaunchpadPreferences {
     static let showMenuBarIconKey = "showMenuBarIcon"
@@ -129,20 +130,7 @@ enum QLaunchAppLauncher {
     }
 }
 
-/// A user-created group of applications. Folder membership is stored by the
-/// stable bundle identifier used by `AppInfo`, so rescanning applications does
-/// not invalidate folders.
-struct AppFolder: Identifiable, Hashable, Codable, Sendable {
-    let id: String
-    var name: String
-    var appIDs: [String]
-
-    init(id: String = "folder-\(UUID().uuidString)", name: String = "文件夹", appIDs: [String]) {
-        self.id = id
-        self.name = name
-        self.appIDs = appIDs
-    }
-}
+typealias AppFolder = QLaunchpadCore.AppFolder
 
 enum LaunchpadItem: Identifiable, Hashable {
     case app(AppInfo)
@@ -461,7 +449,7 @@ final class AppStore: ObservableObject {
     @Published private(set) var customApplicationSourcePaths: [String]
     @Published var showHiddenAppsInSearch: Bool {
         didSet {
-            UserDefaults.standard.set(showHiddenAppsInSearch, forKey: Self.showHiddenAppsKey)
+            UserDefaults.standard.set(showHiddenAppsInSearch, forKey: LaunchpadPersistence.showHiddenAppsKey)
             refreshFilteredApps(resetPage: true)
             NotificationCenter.default.post(name: .qlaunchpadStoreChanged, object: nil)
         }
@@ -498,22 +486,16 @@ final class AppStore: ObservableObject {
     /// Points of scroll delta that equal one full page turn.
     private let pageScrollUnit: Double = 320
 
-    private static let hiddenAppsKey = "hiddenAppIdentifiers"
-    private static let customSourcesKey = "customApplicationSourcePaths"
-    private static let showHiddenAppsKey = "showHiddenAppsInSearch"
-    private static let foldersKey = "launchpadFolders"
-    private static let itemOrderKey = "launchpadItemOrder"
-
     private var itemOrderIDs: [String]
 
     init() {
         let defaults = UserDefaults.standard
-        hiddenAppIDs = Set(defaults.stringArray(forKey: Self.hiddenAppsKey) ?? [])
-        customApplicationSourcePaths = defaults.stringArray(forKey: Self.customSourcesKey) ?? []
-        showHiddenAppsInSearch = defaults.bool(forKey: Self.showHiddenAppsKey)
-        itemOrderIDs = defaults.stringArray(forKey: Self.itemOrderKey) ?? []
-        if let data = defaults.data(forKey: Self.foldersKey),
-           let savedFolders = try? JSONDecoder().decode([AppFolder].self, from: data) {
+        hiddenAppIDs = Set(defaults.stringArray(forKey: LaunchpadPersistence.hiddenAppsKey) ?? [])
+        customApplicationSourcePaths = defaults.stringArray(forKey: LaunchpadPersistence.customSourcesKey) ?? []
+        showHiddenAppsInSearch = defaults.bool(forKey: LaunchpadPersistence.showHiddenAppsKey)
+        itemOrderIDs = defaults.stringArray(forKey: LaunchpadPersistence.itemOrderKey) ?? []
+        if let data = defaults.data(forKey: LaunchpadPersistence.foldersKey),
+           let savedFolders = try? LaunchpadPersistence.decodeFolders(data) {
             folders = savedFolders
         }
     }
@@ -1273,11 +1255,14 @@ final class AppStore: ObservableObject {
     }
 
     private func persistHiddenApps() {
-        UserDefaults.standard.set(hiddenAppIDs.sorted(), forKey: Self.hiddenAppsKey)
+        let next = hiddenAppIDs.sorted()
+        let current = UserDefaults.standard.stringArray(forKey: LaunchpadPersistence.hiddenAppsKey) ?? []
+        guard next != current else { return }
+        UserDefaults.standard.set(next, forKey: LaunchpadPersistence.hiddenAppsKey)
     }
 
     private func persistApplicationSources() {
-        UserDefaults.standard.set(customApplicationSourcePaths, forKey: Self.customSourcesKey)
+        UserDefaults.standard.set(customApplicationSourcePaths, forKey: LaunchpadPersistence.customSourcesKey)
     }
 
     private func isApp(_ item: LaunchpadItem) -> Bool {
@@ -1286,40 +1271,26 @@ final class AppStore: ObservableObject {
     }
 
     private func reconcileLaunchpadItems() {
-        let validApps = Set(apps.map(\.id)).subtracting(hiddenAppIDs)
-        var usedAppIDs = Set<String>()
-        var sanitizedFolders: [AppFolder] = []
-        for folder in folders {
-            let members = folder.appIDs.filter { validApps.contains($0) && usedAppIDs.insert($0).inserted }
-            guard !members.isEmpty else { continue }
-            var sanitized = folder
-            sanitized.appIDs = members
-            sanitizedFolders.append(sanitized)
+        let known = apps.map {
+            LaunchpadKnownApp(
+                id: $0.id,
+                bundleIdentifier: $0.bundleIdentifier,
+                name: $0.name,
+                path: $0.url.standardizedFileURL.path
+            )
         }
-        folders = sanitizedFolders
-
-        let folderByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
-        var validOrder: [String] = []
-        var seen = Set<String>()
-        for id in itemOrderIDs {
-            if let folder = folderByID[id], seen.insert(id).inserted {
-                validOrder.append(folder.id)
-            } else if validApps.contains(id), !usedAppIDs.contains(id), seen.insert(id).inserted {
-                validOrder.append(id)
-            }
-        }
-        for folder in folders where seen.insert(folder.id).inserted {
-            validOrder.append(folder.id)
-        }
-        for app in apps where validApps.contains(app.id)
-            && !usedAppIDs.contains(app.id)
-            && seen.insert(app.id).inserted {
-            validOrder.append(app.id)
-        }
-        itemOrderIDs = validOrder
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: known,
+            folders: folders,
+            order: itemOrderIDs,
+            hidden: hiddenAppIDs
+        )
+        folders = result.folders
+        itemOrderIDs = result.order
         persistFolders()
         persistItemOrder()
-        launchpadItems = validOrder.compactMap { id in
+        let folderByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
+        launchpadItems = itemOrderIDs.compactMap { id in
             if let folder = folderByID[id] { return .folder(folder) }
             guard let app = apps.first(where: { $0.id == id }) else { return nil }
             return .app(app)
@@ -1327,13 +1298,16 @@ final class AppStore: ObservableObject {
     }
 
     private func persistFolders() {
-        if let data = try? JSONEncoder().encode(folders) {
-            UserDefaults.standard.set(data, forKey: Self.foldersKey)
-        }
+        guard let data = try? LaunchpadPersistence.encodeFolders(folders) else { return }
+        let current = UserDefaults.standard.data(forKey: LaunchpadPersistence.foldersKey)
+        guard data != current else { return }
+        UserDefaults.standard.set(data, forKey: LaunchpadPersistence.foldersKey)
     }
 
     private func persistItemOrder() {
-        UserDefaults.standard.set(itemOrderIDs, forKey: Self.itemOrderKey)
+        let current = UserDefaults.standard.stringArray(forKey: LaunchpadPersistence.itemOrderKey) ?? []
+        guard itemOrderIDs != current else { return }
+        UserDefaults.standard.set(itemOrderIDs, forKey: LaunchpadPersistence.itemOrderKey)
     }
 
 }

--- a/Sources/QLaunchpad/GridLayout.swift
+++ b/Sources/QLaunchpad/GridLayout.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import QLaunchpadCore
 
 /// Layout metrics for a Launchpad-style icon grid.
 /// Icon texture pixel size is `iconPointSize * IconRenderQuality.current.rasterScale`
@@ -10,7 +11,7 @@ enum GridLayoutPreset: String, CaseIterable, Identifiable {
     case sixByFour = "6x4-128"
     case sevenByFive = "7x5-128"
 
-    static let defaultsKey = "gridLayoutPreset"
+    static let defaultsKey = LaunchpadPersistence.gridLayoutPresetKey
     static let defaultPreset: Self = .sixByFour
 
     var id: Self { self }

--- a/Sources/QLaunchpadCore/AppFolder.swift
+++ b/Sources/QLaunchpadCore/AppFolder.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A user-created group of applications. Folder membership is stored by the
+/// stable identifier used by `AppInfo`, so rescanning applications does not
+/// invalidate folders.
+public struct AppFolder: Identifiable, Hashable, Codable, Sendable {
+    public let id: String
+    public var name: String
+    public var appIDs: [String]
+
+    public init(id: String = "folder-\(UUID().uuidString)", name: String = "文件夹", appIDs: [String]) {
+        self.id = id
+        self.name = name
+        self.appIDs = appIDs
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadLayout.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayout.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+public enum LaunchpadLayoutKind {
+    public static let current = "qlaunchpad.layout"
+    public static let schemaVersion = 1
+}
+
+public struct LaunchpadLayoutDocument: Equatable, Sendable {
+    public var kind: String
+    public var schemaVersion: Int
+    public var exportedAt: Date?
+    public var appVersion: String?
+    public var grid: LaunchpadLayoutGrid?
+    public var items: [LaunchpadLayoutItem]
+    public var hidden: [String]?
+    public var catalog: [LaunchpadLayoutCatalogEntry]?
+
+    public init(
+        kind: String = LaunchpadLayoutKind.current,
+        schemaVersion: Int = LaunchpadLayoutKind.schemaVersion,
+        exportedAt: Date? = nil,
+        appVersion: String? = nil,
+        grid: LaunchpadLayoutGrid? = nil,
+        items: [LaunchpadLayoutItem],
+        hidden: [String]? = nil,
+        catalog: [LaunchpadLayoutCatalogEntry]? = nil
+    ) {
+        self.kind = kind
+        self.schemaVersion = schemaVersion
+        self.exportedAt = exportedAt
+        self.appVersion = appVersion
+        self.grid = grid
+        self.items = items
+        self.hidden = hidden
+        self.catalog = catalog
+    }
+
+    /// Pretty + sortedKeys + ISO-8601. Not the on-disk folders encoder.
+    public static func makeEncoder(pretty: Bool = true) -> JSONEncoder {
+        let encoder = JSONEncoder()
+        var formatting: JSONEncoder.OutputFormatting = [.sortedKeys]
+        if pretty {
+            formatting.insert(.prettyPrinted)
+        }
+        encoder.outputFormatting = formatting
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    public static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+public enum LaunchpadLayoutItem: Equatable, Sendable {
+    case app(id: String)
+    case folder(id: String?, name: String, apps: [String])
+}
+
+public struct LaunchpadLayoutGrid: Codable, Equatable, Sendable {
+    public var preset: String
+    public var columns: Int
+    public var rows: Int
+    public var pageCapacity: Int
+
+    public init(preset: String, columns: Int, rows: Int, pageCapacity: Int) {
+        self.preset = preset
+        self.columns = columns
+        self.rows = rows
+        self.pageCapacity = pageCapacity
+    }
+}
+
+public struct LaunchpadLayoutCatalogEntry: Codable, Equatable, Sendable {
+    public var id: String
+    public var bundleIdentifier: String
+    public var name: String
+    public var path: String?
+
+    public init(id: String, bundleIdentifier: String, name: String, path: String? = nil) {
+        self.id = id
+        self.bundleIdentifier = bundleIdentifier
+        self.name = name
+        self.path = path
+    }
+}
+
+public struct LaunchpadKnownApp: Equatable, Sendable {
+    public var id: String
+    public var bundleIdentifier: String
+    public var name: String
+    public var path: String
+
+    public init(id: String, bundleIdentifier: String, name: String, path: String) {
+        self.id = id
+        self.bundleIdentifier = bundleIdentifier
+        self.name = name
+        self.path = path
+    }
+}
+
+public enum LaunchpadLayoutImportMode: String, Sendable {
+    case merge
+    case replace
+}
+
+public struct LaunchpadLayoutReport: Equatable, Sendable {
+    public var importedRootItems: Int
+    public var importedFolders: Int
+    public var resolvedApps: Int
+    public var skippedUnknown: [String]
+    public var appendedLeftover: [String]
+    public var hiddenReplaced: Bool
+    public var unhiddenByClaim: [String]
+    public var newlyHiddenByReplace: [String]
+
+    public init(
+        importedRootItems: Int,
+        importedFolders: Int,
+        resolvedApps: Int,
+        skippedUnknown: [String],
+        appendedLeftover: [String],
+        hiddenReplaced: Bool,
+        unhiddenByClaim: [String],
+        newlyHiddenByReplace: [String]
+    ) {
+        self.importedRootItems = importedRootItems
+        self.importedFolders = importedFolders
+        self.resolvedApps = resolvedApps
+        self.skippedUnknown = skippedUnknown
+        self.appendedLeftover = appendedLeftover
+        self.hiddenReplaced = hiddenReplaced
+        self.unhiddenByClaim = unhiddenByClaim
+        self.newlyHiddenByReplace = newlyHiddenByReplace
+    }
+}
+
+public enum LaunchpadLayoutError: Error, Equatable {
+    case invalidKind(String)
+    case unsupportedSchemaVersion(Int)
+    case malformed(String)
+    case limitExceeded(String)
+    case duplicateID(String)
+    case nestedFolder(String)
+    case itemHiddenOverlap(String)
+    case strictUnresolved([String])
+}
+
+extension LaunchpadLayoutDocument: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case schemaVersion
+        case exportedAt
+        case appVersion
+        case grid
+        case items
+        case hidden
+        case catalog
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try container.decode(String.self, forKey: .kind)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        exportedAt = try container.decodeIfPresent(Date.self, forKey: .exportedAt)
+        appVersion = try container.decodeIfPresent(String.self, forKey: .appVersion)
+        grid = try container.decodeIfPresent(LaunchpadLayoutGrid.self, forKey: .grid)
+        items = try container.decode([LaunchpadLayoutItem].self, forKey: .items)
+        hidden = try container.decodeIfPresent([String].self, forKey: .hidden)
+        catalog = try container.decodeIfPresent([LaunchpadLayoutCatalogEntry].self, forKey: .catalog)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encodeIfPresent(exportedAt, forKey: .exportedAt)
+        try container.encodeIfPresent(appVersion, forKey: .appVersion)
+        try container.encodeIfPresent(grid, forKey: .grid)
+        try container.encode(items, forKey: .items)
+        try container.encodeIfPresent(hidden, forKey: .hidden)
+        try container.encodeIfPresent(catalog, forKey: .catalog)
+    }
+}
+
+extension LaunchpadLayoutItem: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case id
+        case name
+        case apps
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "app":
+            self = .app(id: try container.decode(String.self, forKey: .id))
+        case "folder":
+            self = .folder(
+                id: try container.decodeIfPresent(String.self, forKey: .id),
+                name: try container.decode(String.self, forKey: .name),
+                apps: try container.decode([String].self, forKey: .apps)
+            )
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unsupported layout item type '\(type)'"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .app(let id):
+            try container.encode("app", forKey: .type)
+            try container.encode(id, forKey: .id)
+        case .folder(let id, let name, let apps):
+            try container.encode("folder", forKey: .type)
+            try container.encodeIfPresent(id, forKey: .id)
+            try container.encode(name, forKey: .name)
+            try container.encode(apps, forKey: .apps)
+        }
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadLayoutImporter.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayoutImporter.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+public enum LaunchpadLayoutImporter {
+    public static let maxJSONBytes = 5 * 1024 * 1024
+    public static let maxItems = 10_000
+    public static let maxFolders = 2_000
+    public static let maxFolderMembers = 500
+    public static let maxNameScalars = 200
+    public static let maxCatalogEntries = 10_000
+
+    public static func apply(
+        document: LaunchpadLayoutDocument,
+        mode: LaunchpadLayoutImportMode,
+        strict: Bool,
+        scanned: [LaunchpadKnownApp],
+        currentHidden: Set<String>
+    ) throws -> (
+        layout: (folders: [AppFolder], order: [String], hidden: Set<String>),
+        report: LaunchpadLayoutReport
+    ) {
+        try validate(document)
+
+        var resolvedByRawID: [String: LaunchpadKnownApp] = [:]
+        var skippedUnknown: [String] = []
+        var seenReferenced = Set<String>()
+        for rawID in referencedIDs(in: document) {
+            guard seenReferenced.insert(rawID).inserted else { continue }
+            if let resolved = LaunchpadLayoutResolver.resolve(
+                rawID: rawID,
+                scanned: scanned,
+                catalog: document.catalog
+            ) {
+                resolvedByRawID[rawID] = resolved
+            } else {
+                skippedUnknown.append(rawID)
+            }
+        }
+
+        if strict {
+            if !skippedUnknown.isEmpty {
+                throw LaunchpadLayoutError.strictUnresolved(skippedUnknown)
+            }
+            for item in document.items {
+                if case .folder(_, let name, _) = item,
+                   name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    throw LaunchpadLayoutError.malformed("empty folder name")
+                }
+            }
+        }
+
+        var proposedFolders: [AppFolder] = []
+        var proposedOrder: [String] = []
+        for item in document.items {
+            switch item {
+            case .app(let rawID):
+                guard let resolved = resolvedByRawID[rawID] else { continue }
+                proposedOrder.append(resolved.id)
+            case .folder(let rawID, let name, let apps):
+                let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+                let folderName = trimmedName.isEmpty ? "文件夹" : trimmedName
+                let folderID = normalizedFolderID(rawID)
+                let members = apps.compactMap { resolvedByRawID[$0]?.id }
+                proposedFolders.append(AppFolder(id: folderID, name: folderName, appIDs: members))
+                proposedOrder.append(folderID)
+            }
+        }
+
+        let resolvedAppIDs = Set(resolvedByRawID.values.map(\.id))
+        for folder in proposedFolders where resolvedAppIDs.contains(folder.id) {
+            throw LaunchpadLayoutError.duplicateID(folder.id)
+        }
+
+        var claimedIDs = Set<String>()
+        for folder in proposedFolders {
+            claimedIDs.formUnion(folder.appIDs)
+        }
+        let folderIDs = Set(proposedFolders.map(\.id))
+        for id in proposedOrder where !folderIDs.contains(id) {
+            claimedIDs.insert(id)
+        }
+
+        let hiddenReplaced = document.hidden != nil
+        let hiddenBaseline: Set<String>
+        let unhiddenByClaim: [String]
+        if let hidden = document.hidden {
+            hiddenBaseline = Set(hidden.compactMap { resolvedByRawID[$0]?.id })
+            unhiddenByClaim = []
+            for id in claimedIDs where hiddenBaseline.contains(id) {
+                throw LaunchpadLayoutError.itemHiddenOverlap(id)
+            }
+        } else {
+            hiddenBaseline = currentHidden.subtracting(claimedIDs)
+            unhiddenByClaim = currentHidden.intersection(claimedIDs).sorted()
+        }
+
+        let leftoverIDs = scanned
+            .filter { !claimedIDs.contains($0.id) && !hiddenBaseline.contains($0.id) }
+            .sorted(by: Self.appSort)
+            .map(\.id)
+
+        let newlyHiddenByReplace: [String]
+        let finalHidden: Set<String>
+        if mode == .replace {
+            newlyHiddenByReplace = leftoverIDs
+            finalHidden = hiddenBaseline.union(leftoverIDs)
+        } else {
+            newlyHiddenByReplace = []
+            finalHidden = hiddenBaseline
+        }
+
+        let reconciled = LaunchpadLayoutReconciler.reconcile(
+            apps: scanned,
+            folders: proposedFolders,
+            order: proposedOrder,
+            hidden: finalHidden
+        )
+
+        let leftoverInOrder = mode == .merge ? leftoverIDs : []
+        let report = LaunchpadLayoutReport(
+            importedRootItems: reconciled.order.count - leftoverInOrder.count,
+            importedFolders: reconciled.folders.count,
+            resolvedApps: resolvedByRawID.count,
+            skippedUnknown: skippedUnknown,
+            appendedLeftover: leftoverInOrder,
+            hiddenReplaced: hiddenReplaced,
+            unhiddenByClaim: unhiddenByClaim,
+            newlyHiddenByReplace: newlyHiddenByReplace
+        )
+        return (
+            layout: (folders: reconciled.folders, order: reconciled.order, hidden: finalHidden),
+            report: report
+        )
+    }
+
+    public static func validate(_ document: LaunchpadLayoutDocument) throws {
+        if document.kind != LaunchpadLayoutKind.current {
+            throw LaunchpadLayoutError.invalidKind(document.kind)
+        }
+        if document.schemaVersion != LaunchpadLayoutKind.schemaVersion {
+            throw LaunchpadLayoutError.unsupportedSchemaVersion(document.schemaVersion)
+        }
+        if document.items.count > maxItems {
+            throw LaunchpadLayoutError.limitExceeded("items")
+        }
+        let folderCount = document.items.reduce(0) { count, item in
+            if case .folder = item { return count + 1 }
+            return count
+        }
+        if folderCount > maxFolders {
+            throw LaunchpadLayoutError.limitExceeded("folders")
+        }
+        if let catalog = document.catalog, catalog.count > maxCatalogEntries {
+            throw LaunchpadLayoutError.limitExceeded("catalog")
+        }
+
+        var folderIDs = Set<String>()
+        for item in document.items {
+            if case .folder(let id, _, _) = item, let id {
+                try rejectInvalidString(id)
+                folderIDs.insert(id)
+            }
+        }
+
+        var seenIDs = Set<String>()
+        for item in document.items {
+            switch item {
+            case .app(let id):
+                try rejectInvalidString(id)
+                if !seenIDs.insert(id).inserted {
+                    throw LaunchpadLayoutError.duplicateID(id)
+                }
+            case .folder(let id, let name, let apps):
+                if name.unicodeScalars.contains("\0") {
+                    throw LaunchpadLayoutError.malformed("string contains NUL")
+                }
+                if name.unicodeScalars.count > maxNameScalars {
+                    throw LaunchpadLayoutError.limitExceeded("name")
+                }
+                if let id {
+                    if !seenIDs.insert(id).inserted {
+                        throw LaunchpadLayoutError.duplicateID(id)
+                    }
+                }
+                if apps.count > maxFolderMembers {
+                    throw LaunchpadLayoutError.limitExceeded("folder members")
+                }
+                for appID in apps {
+                    try rejectInvalidString(appID)
+                    if folderIDs.contains(appID) {
+                        throw LaunchpadLayoutError.nestedFolder(appID)
+                    }
+                    if !seenIDs.insert(appID).inserted {
+                        throw LaunchpadLayoutError.duplicateID(appID)
+                    }
+                }
+            }
+        }
+
+        if let hidden = document.hidden {
+            var seenHidden = Set<String>()
+            for id in hidden {
+                try rejectInvalidString(id)
+                if !seenHidden.insert(id).inserted {
+                    throw LaunchpadLayoutError.duplicateID(id)
+                }
+                if seenIDs.contains(id) {
+                    throw LaunchpadLayoutError.itemHiddenOverlap(id)
+                }
+            }
+        }
+
+        if let catalog = document.catalog {
+            for entry in catalog {
+                try rejectInvalidString(entry.id)
+                try rejectInvalidString(entry.bundleIdentifier)
+                try rejectInvalidString(entry.name)
+                if let path = entry.path {
+                    try rejectInvalidString(path)
+                }
+            }
+        }
+    }
+
+    public static func validateJSONSize(_ data: Data) throws {
+        if data.count > maxJSONBytes {
+            throw LaunchpadLayoutError.limitExceeded("json")
+        }
+    }
+
+    private static func referencedIDs(in document: LaunchpadLayoutDocument) -> [String] {
+        var ids: [String] = []
+        for item in document.items {
+            switch item {
+            case .app(let id):
+                ids.append(id)
+            case .folder(_, _, let apps):
+                ids.append(contentsOf: apps)
+            }
+        }
+        if let hidden = document.hidden {
+            ids.append(contentsOf: hidden)
+        }
+        return ids
+    }
+
+    private static func normalizedFolderID(_ rawID: String?) -> String {
+        guard let rawID else {
+            return "folder-\(UUID().uuidString)"
+        }
+        let trimmed = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "folder-\(UUID().uuidString)" : trimmed
+    }
+
+    private static func rejectInvalidString(_ value: String) throws {
+        if value.unicodeScalars.contains("\0") {
+            throw LaunchpadLayoutError.malformed("string contains NUL")
+        }
+        if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw LaunchpadLayoutError.malformed("empty string")
+        }
+    }
+
+    private static func appSort(_ lhs: LaunchpadKnownApp, _ rhs: LaunchpadKnownApp) -> Bool {
+        let nameOrder = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+        if nameOrder != .orderedSame {
+            return nameOrder == .orderedAscending
+        }
+        return lhs.path < rhs.path
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadLayoutImporter.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayoutImporter.swift
@@ -36,6 +36,14 @@ public enum LaunchpadLayoutImporter {
             }
         }
 
+        var seenResolvedIDs = Set<String>()
+        for rawID in referencedIDs(in: document, includeHidden: false) {
+            guard let resolved = resolvedByRawID[rawID] else { continue }
+            if !seenResolvedIDs.insert(resolved.id).inserted {
+                throw LaunchpadLayoutError.duplicateID(resolved.id)
+            }
+        }
+
         if strict {
             if !skippedUnknown.isEmpty {
                 throw LaunchpadLayoutError.strictUnresolved(skippedUnknown)
@@ -65,8 +73,8 @@ public enum LaunchpadLayoutImporter {
             }
         }
 
-        let resolvedAppIDs = Set(resolvedByRawID.values.map(\.id))
-        for folder in proposedFolders where resolvedAppIDs.contains(folder.id) {
+        let scannedIDs = Set(scanned.map(\.id))
+        for folder in proposedFolders where scannedIDs.contains(folder.id) {
             throw LaunchpadLayoutError.duplicateID(folder.id)
         }
 
@@ -157,7 +165,10 @@ public enum LaunchpadLayoutImporter {
         for item in document.items {
             if case .folder(let id, _, _) = item, let id {
                 try rejectInvalidString(id)
-                folderIDs.insert(id)
+                let identity = folderIdentity(id)
+                if !folderIDs.insert(identity).inserted {
+                    throw LaunchpadLayoutError.duplicateID(identity)
+                }
             }
         }
 
@@ -177,8 +188,9 @@ public enum LaunchpadLayoutImporter {
                     throw LaunchpadLayoutError.limitExceeded("name")
                 }
                 if let id {
-                    if !seenIDs.insert(id).inserted {
-                        throw LaunchpadLayoutError.duplicateID(id)
+                    let identity = folderIdentity(id)
+                    if !seenIDs.insert(identity).inserted {
+                        throw LaunchpadLayoutError.duplicateID(identity)
                     }
                 }
                 if apps.count > maxFolderMembers {
@@ -186,7 +198,7 @@ public enum LaunchpadLayoutImporter {
                 }
                 for appID in apps {
                     try rejectInvalidString(appID)
-                    if folderIDs.contains(appID) {
+                    if folderIDs.contains(folderIdentity(appID)) {
                         throw LaunchpadLayoutError.nestedFolder(appID)
                     }
                     if !seenIDs.insert(appID).inserted {
@@ -227,7 +239,10 @@ public enum LaunchpadLayoutImporter {
         }
     }
 
-    private static func referencedIDs(in document: LaunchpadLayoutDocument) -> [String] {
+    private static func referencedIDs(
+        in document: LaunchpadLayoutDocument,
+        includeHidden: Bool = true
+    ) -> [String] {
         var ids: [String] = []
         for item in document.items {
             switch item {
@@ -237,17 +252,21 @@ public enum LaunchpadLayoutImporter {
                 ids.append(contentsOf: apps)
             }
         }
-        if let hidden = document.hidden {
+        if includeHidden, let hidden = document.hidden {
             ids.append(contentsOf: hidden)
         }
         return ids
+    }
+
+    private static func folderIdentity(_ rawID: String) -> String {
+        rawID.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func normalizedFolderID(_ rawID: String?) -> String {
         guard let rawID else {
             return "folder-\(UUID().uuidString)"
         }
-        let trimmed = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = folderIdentity(rawID)
         return trimmed.isEmpty ? "folder-\(UUID().uuidString)" : trimmed
     }
 

--- a/Sources/QLaunchpadCore/LaunchpadLayoutReconciler.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayoutReconciler.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public enum LaunchpadLayoutReconciler {
+    /// Matches `AppStore.reconcileLaunchpadItems()`: drop empty folders, strip
+    /// hidden members, keep the first copy of a duplicated app, append folders
+    /// missing from `order` before leftover apps.
+    public static func reconcile(
+        apps: [LaunchpadKnownApp],
+        folders: [AppFolder],
+        order: [String],
+        hidden: Set<String>
+    ) -> (folders: [AppFolder], order: [String]) {
+        let validApps = Set(apps.map(\.id)).subtracting(hidden)
+        var usedAppIDs = Set<String>()
+        var sanitizedFolders: [AppFolder] = []
+        for folder in folders {
+            let members = folder.appIDs.filter { validApps.contains($0) && usedAppIDs.insert($0).inserted }
+            guard !members.isEmpty else { continue }
+            var sanitized = folder
+            sanitized.appIDs = members
+            sanitizedFolders.append(sanitized)
+        }
+
+        let folderByID = Dictionary(uniqueKeysWithValues: sanitizedFolders.map { ($0.id, $0) })
+        var validOrder: [String] = []
+        var seen = Set<String>()
+        for id in order {
+            if let folder = folderByID[id], seen.insert(id).inserted {
+                validOrder.append(folder.id)
+            } else if validApps.contains(id), !usedAppIDs.contains(id), seen.insert(id).inserted {
+                validOrder.append(id)
+            }
+        }
+        for folder in sanitizedFolders where seen.insert(folder.id).inserted {
+            validOrder.append(folder.id)
+        }
+        for app in apps where validApps.contains(app.id)
+            && !usedAppIDs.contains(app.id)
+            && seen.insert(app.id).inserted {
+            validOrder.append(app.id)
+        }
+        return (sanitizedFolders, validOrder)
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadLayoutResolver.swift
+++ b/Sources/QLaunchpadCore/LaunchpadLayoutResolver.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+public enum LaunchpadLayoutResolver {
+    public static func resolve(
+        rawID: String,
+        scanned: [LaunchpadKnownApp],
+        catalog: [LaunchpadLayoutCatalogEntry]?
+    ) -> LaunchpadKnownApp? {
+        if let exact = scanned.first(where: { $0.id == rawID }) {
+            return exact
+        }
+
+        if let parsed = parseCompositeID(rawID) {
+            let standardized = standardizedPath(parsed.path)
+            if let match = scanned.first(where: {
+                $0.bundleIdentifier == parsed.bundle
+                    && standardizedPath($0.path) == standardized
+            }) {
+                return match
+            }
+        }
+
+        if let catalog,
+           let entry = catalog.first(where: { $0.id == rawID }),
+           let path = entry.path {
+            let standardized = standardizedPath(path)
+            if let match = scanned.first(where: {
+                $0.bundleIdentifier == entry.bundleIdentifier
+                    && standardizedPath($0.path) == standardized
+            }) {
+                return match
+            }
+        }
+
+        let bundle = parseCompositeID(rawID)?.bundle ?? rawID
+        let copies = scanned.filter { $0.bundleIdentifier == bundle }
+        if copies.count == 1 {
+            return copies[0]
+        }
+
+        return nil
+    }
+
+    private static func parseCompositeID(_ rawID: String) -> (bundle: String, path: String)? {
+        guard let hash = rawID.firstIndex(of: "#") else { return nil }
+        let bundle = String(rawID[..<hash])
+        let path = String(rawID[rawID.index(after: hash)...])
+        guard !bundle.isEmpty, !path.isEmpty else { return nil }
+        return (bundle, path)
+    }
+
+    private static func standardizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+}

--- a/Sources/QLaunchpadCore/LaunchpadPersistence.swift
+++ b/Sources/QLaunchpadCore/LaunchpadPersistence.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public enum LaunchpadPersistence {
+    public static let hiddenAppsKey = "hiddenAppIdentifiers"
+    public static let customSourcesKey = "customApplicationSourcePaths"
+    public static let showHiddenAppsKey = "showHiddenAppsInSearch"
+    public static let foldersKey = "launchpadFolders"
+    public static let itemOrderKey = "launchpadItemOrder"
+    public static let gridLayoutPresetKey = "gridLayoutPreset"
+
+    /// Compact `[{id,name,appIDs}]`. Key order is fixed so persist-if-changed
+    /// can compare encoded `Data` without false dirty writes.
+    public static func encodeFolders(_ folders: [AppFolder]) throws -> Data {
+        let encoder = JSONEncoder()
+        var json = Data([UInt8(ascii: "[")])
+        for (index, folder) in folders.enumerated() {
+            if index > 0 {
+                json.append(UInt8(ascii: ","))
+            }
+            json.append(UInt8(ascii: "{"))
+            json.append(contentsOf: "\"id\":".utf8)
+            json.append(try encoder.encode(folder.id))
+            json.append(contentsOf: ",\"name\":".utf8)
+            json.append(try encoder.encode(folder.name))
+            json.append(contentsOf: ",\"appIDs\":[".utf8)
+            for (appIndex, appID) in folder.appIDs.enumerated() {
+                if appIndex > 0 {
+                    json.append(UInt8(ascii: ","))
+                }
+                json.append(try encoder.encode(appID))
+            }
+            json.append(contentsOf: "]}".utf8)
+        }
+        json.append(UInt8(ascii: "]"))
+        return json
+    }
+
+    public static func decodeFolders(_ data: Data) throws -> [AppFolder] {
+        try JSONDecoder().decode([AppFolder].self, from: data)
+    }
+}

--- a/Tests/QLaunchpadCoreTests/Fixtures/canonical-layout.json
+++ b/Tests/QLaunchpadCoreTests/Fixtures/canonical-layout.json
@@ -1,0 +1,48 @@
+{
+  "appVersion" : "1.0.0",
+  "catalog" : [
+    {
+      "bundleIdentifier" : "com.apple.Safari",
+      "id" : "com.apple.Safari",
+      "name" : "Safari",
+      "path" : "\/System\/Cryptexes\/App\/System\/Applications\/Safari.app"
+    },
+    {
+      "bundleIdentifier" : "com.example.Foo",
+      "id" : "com.example.Foo#\/Users\/alex\/Applications\/Foo.app",
+      "name" : "Foo",
+      "path" : "\/Users\/alex\/Applications\/Foo.app"
+    }
+  ],
+  "exportedAt" : "2026-08-13T04:12:00Z",
+  "grid" : {
+    "columns" : 6,
+    "pageCapacity" : 24,
+    "preset" : "6x4-128",
+    "rows" : 4
+  },
+  "hidden" : [
+    "com.apple.Chess"
+  ],
+  "items" : [
+    {
+      "id" : "com.apple.Safari",
+      "type" : "app"
+    },
+    {
+      "apps" : [
+        "com.apple.dt.Xcode",
+        "com.microsoft.VSCode"
+      ],
+      "id" : "folder-550e8400-e29b-41d4-a716-446655440000",
+      "name" : "开发",
+      "type" : "folder"
+    },
+    {
+      "id" : "com.apple.Preview",
+      "type" : "app"
+    }
+  ],
+  "kind" : "qlaunchpad.layout",
+  "schemaVersion" : 1
+}

--- a/Tests/QLaunchpadCoreTests/Fixtures/persist-folders.json
+++ b/Tests/QLaunchpadCoreTests/Fixtures/persist-folders.json
@@ -1,0 +1,1 @@
+[{"id":"folder-550e8400-e29b-41d4-a716-446655440000","name":"开发","appIDs":["com.apple.dt.Xcode","com.microsoft.VSCode"]}]

--- a/Tests/QLaunchpadCoreTests/LaunchpadLayoutTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadLayoutTests.swift
@@ -271,6 +271,81 @@ final class LaunchpadLayoutTests: XCTestCase {
         XCTAssertEqual(folders.first?.appIDs, ["com.apple.dt.Xcode", "com.microsoft.VSCode"])
     }
 
+    func testDecodeFoldersAcceptsHistoricalJSONEncoderPayload() throws {
+        let historical = Data(
+            #"[{"id":"folder-550e8400-e29b-41d4-a716-446655440000","appIDs":["com.example.Foo#\/Users\/alex\/Applications\/Foo.app"],"name":"开发"}]"#.utf8
+        )
+        let folders = try LaunchpadPersistence.decodeFolders(historical)
+        XCTAssertEqual(folders.map(\.id), ["folder-550e8400-e29b-41d4-a716-446655440000"])
+        XCTAssertEqual(folders.first?.name, "开发")
+        XCTAssertEqual(
+            folders.first?.appIDs,
+            ["com.example.Foo#/Users/alex/Applications/Foo.app"]
+        )
+    }
+
+    func testTrimmedFolderIDsAreUnique() {
+        let document = LaunchpadLayoutDocument(items: [
+            .folder(id: "folder-a", name: "A", apps: ["com.alpha"]),
+            .folder(id: " folder-a", name: "B", apps: ["com.bravo"])
+        ])
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: document,
+                mode: .merge,
+                strict: false,
+                scanned: known(
+                    ("com.alpha", "Alpha", "/A/Alpha.app"),
+                    ("com.bravo", "Bravo", "/B/Bravo.app")
+                ),
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .duplicateID("folder-a"))
+        }
+    }
+
+    func testFolderIDCollidingWithLeftoverScannedAppRejected() {
+        let document = LaunchpadLayoutDocument(items: [
+            .folder(id: "folder-collide", name: "X", apps: ["com.alpha"])
+        ])
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: document,
+                mode: .merge,
+                strict: false,
+                scanned: known(
+                    ("com.alpha", "Alpha", "/A/Alpha.app"),
+                    ("folder-collide", "Collide", "/C/Collide.app")
+                ),
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .duplicateID("folder-collide"))
+        }
+    }
+
+    func testResolvedIDAliasesRejectedAsDuplicate() {
+        let scanned = known(
+            ("com.example.Foo", "Foo", "/Users/alex/Applications/Foo.app")
+        )
+        let document = LaunchpadLayoutDocument(items: [
+            .app(id: "com.example.Foo"),
+            .app(id: "com.example.Foo#/Users/alex/Applications/Foo.app")
+        ])
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: document,
+                mode: .merge,
+                strict: false,
+                scanned: scanned,
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .duplicateID("com.example.Foo"))
+        }
+    }
+
     private func known(_ items: (String, String, String)...) -> [LaunchpadKnownApp] {
         items
             .map { LaunchpadKnownApp(id: $0.0, bundleIdentifier: $0.0, name: $0.1, path: $0.2) }

--- a/Tests/QLaunchpadCoreTests/LaunchpadLayoutTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadLayoutTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+@testable import QLaunchpadCore
+
+final class LaunchpadLayoutTests: XCTestCase {
+    func testEmptyFolderDropped() {
+        let apps = known(
+            ("com.alpha", "Alpha", "/A/Alpha.app"),
+            ("com.bravo", "Bravo", "/A/Bravo.app")
+        )
+        let folders = [
+            AppFolder(id: "folder-empty", name: "Empty", appIDs: []),
+            AppFolder(id: "folder-keep", name: "Keep", appIDs: ["com.alpha"])
+        ]
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: apps,
+            folders: folders,
+            order: ["folder-empty", "com.bravo", "folder-keep"],
+            hidden: []
+        )
+        XCTAssertEqual(result.folders.map(\.id), ["folder-keep"])
+        XCTAssertEqual(result.order, ["com.bravo", "folder-keep"])
+    }
+
+    func testHiddenMembersStrippedFromFolderAndOrder() {
+        let apps = known(
+            ("com.alpha", "Alpha", "/A/Alpha.app"),
+            ("com.bravo", "Bravo", "/A/Bravo.app"),
+            ("com.charlie", "Charlie", "/A/Charlie.app")
+        )
+        let folders = [
+            AppFolder(id: "folder-dev", name: "Dev", appIDs: ["com.alpha", "com.bravo"])
+        ]
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: apps,
+            folders: folders,
+            order: ["folder-dev", "com.charlie", "com.bravo"],
+            hidden: ["com.bravo"]
+        )
+        XCTAssertEqual(result.folders.map(\.appIDs), [["com.alpha"]])
+        XCTAssertEqual(result.order, ["folder-dev", "com.charlie"])
+        XCTAssertFalse(result.order.contains("com.bravo"))
+    }
+
+    func testDuplicateAppKeepsFirstFolder() {
+        let apps = known(
+            ("com.alpha", "Alpha", "/A/Alpha.app"),
+            ("com.bravo", "Bravo", "/A/Bravo.app")
+        )
+        let folders = [
+            AppFolder(id: "folder-a", name: "A", appIDs: ["com.alpha"]),
+            AppFolder(id: "folder-b", name: "B", appIDs: ["com.alpha", "com.bravo"])
+        ]
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: apps,
+            folders: folders,
+            order: ["folder-a", "folder-b"],
+            hidden: []
+        )
+        XCTAssertEqual(result.folders.map(\.id), ["folder-a", "folder-b"])
+        XCTAssertEqual(result.folders[0].appIDs, ["com.alpha"])
+        XCTAssertEqual(result.folders[1].appIDs, ["com.bravo"])
+    }
+
+    func testLeftoverAppendOrderAndMissingFolderBeforeLeftoverApps() {
+        let apps = known(
+            ("com.zebra", "Zebra", "/Z/Zebra.app"),
+            ("com.apple.b", "Apple", "/B/Apple.app"),
+            ("com.apple.a", "Apple", "/A/Apple.app"),
+            ("com.kept", "Kept", "/K/Kept.app")
+        )
+        let folders = [
+            AppFolder(id: "folder-late", name: "Late", appIDs: ["com.kept"])
+        ]
+        let result = LaunchpadLayoutReconciler.reconcile(
+            apps: apps,
+            folders: folders,
+            order: ["com.zebra"],
+            hidden: []
+        )
+        XCTAssertEqual(
+            result.order,
+            ["com.zebra", "folder-late", "com.apple.a", "com.apple.b"]
+        )
+    }
+
+    func testItemsHiddenOverlapRejected() {
+        let document = LaunchpadLayoutDocument(
+            items: [
+                .app(id: "com.apple.Safari"),
+                .folder(id: "folder-dev", name: "开发", apps: ["com.apple.dt.Xcode"])
+            ],
+            hidden: ["com.apple.Safari"]
+        )
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: document,
+                mode: .merge,
+                strict: false,
+                scanned: known(("com.apple.Safari", "Safari", "/S/Safari.app")),
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .itemHiddenOverlap("com.apple.Safari"))
+        }
+
+        let folderOverlap = LaunchpadLayoutDocument(
+            items: [
+                .folder(id: "folder-dev", name: "开发", apps: ["com.apple.dt.Xcode"])
+            ],
+            hidden: ["com.apple.dt.Xcode"]
+        )
+        XCTAssertThrowsError(
+            try LaunchpadLayoutImporter.apply(
+                document: folderOverlap,
+                mode: .merge,
+                strict: false,
+                scanned: known(("com.apple.dt.Xcode", "Xcode", "/X/Xcode.app")),
+                currentHidden: []
+            )
+        ) { error in
+            XCTAssertEqual(error as? LaunchpadLayoutError, .itemHiddenOverlap("com.apple.dt.Xcode"))
+        }
+    }
+
+    func testCompositeIDResolvesWhenOnlyBareCopyRemains() throws {
+        let scanned = known(
+            ("com.example.Foo", "Foo", "/Users/alex/Applications/Foo.app")
+        )
+        let rawID = "com.example.Foo#/Users/alex/Applications/Foo.app"
+        let resolved = LaunchpadLayoutResolver.resolve(rawID: rawID, scanned: scanned, catalog: nil)
+        XCTAssertEqual(resolved?.id, "com.example.Foo")
+
+        let document = LaunchpadLayoutDocument(items: [.app(id: rawID)])
+        let result = try LaunchpadLayoutImporter.apply(
+            document: document,
+            mode: .merge,
+            strict: true,
+            scanned: scanned,
+            currentHidden: []
+        )
+        XCTAssertEqual(result.layout.order, ["com.example.Foo"])
+        XCTAssertEqual(result.report.resolvedApps, 1)
+        XCTAssertTrue(result.report.skippedUnknown.isEmpty)
+    }
+
+    func testReplaceHidesLeftoversBeforeReconcile() throws {
+        let scanned = known(
+            ("com.kept", "Kept", "/K/Kept.app"),
+            ("com.extra", "Extra", "/E/Extra.app")
+        )
+        let document = LaunchpadLayoutDocument(items: [.app(id: "com.kept")])
+        let result = try LaunchpadLayoutImporter.apply(
+            document: document,
+            mode: .replace,
+            strict: false,
+            scanned: scanned,
+            currentHidden: []
+        )
+        XCTAssertEqual(result.layout.order, ["com.kept"])
+        XCTAssertTrue(result.layout.hidden.contains("com.extra"))
+        XCTAssertFalse(result.layout.order.contains("com.extra"))
+        XCTAssertEqual(result.report.newlyHiddenByReplace, ["com.extra"])
+        XCTAssertTrue(result.report.appendedLeftover.isEmpty)
+    }
+
+    func testHiddenOmittedVersusPresentThreeState() throws {
+        let scanned = known(
+            ("com.alpha", "Alpha", "/A/Alpha.app"),
+            ("com.bravo", "Bravo", "/B/Bravo.app"),
+            ("com.hidden", "Hidden", "/H/Hidden.app")
+        )
+        let currentHidden: Set<String> = ["com.hidden"]
+
+        let omitted = try LaunchpadLayoutImporter.apply(
+            document: LaunchpadLayoutDocument(items: [.app(id: "com.alpha")]),
+            mode: .merge,
+            strict: false,
+            scanned: scanned,
+            currentHidden: currentHidden
+        )
+        XCTAssertEqual(omitted.layout.hidden, ["com.hidden"])
+        XCTAssertFalse(omitted.report.hiddenReplaced)
+        XCTAssertEqual(omitted.report.appendedLeftover, ["com.bravo"])
+        XCTAssertTrue(omitted.layout.order.contains("com.bravo"))
+
+        let replaced = try LaunchpadLayoutImporter.apply(
+            document: LaunchpadLayoutDocument(
+                items: [.app(id: "com.alpha")],
+                hidden: ["com.bravo"]
+            ),
+            mode: .merge,
+            strict: false,
+            scanned: scanned,
+            currentHidden: currentHidden
+        )
+        XCTAssertEqual(replaced.layout.hidden, ["com.bravo"])
+        XCTAssertTrue(replaced.report.hiddenReplaced)
+        XCTAssertTrue(replaced.layout.order.contains("com.hidden"))
+        XCTAssertFalse(replaced.layout.order.contains("com.bravo"))
+
+        let emptied = try LaunchpadLayoutImporter.apply(
+            document: LaunchpadLayoutDocument(
+                items: [.app(id: "com.alpha")],
+                hidden: []
+            ),
+            mode: .merge,
+            strict: false,
+            scanned: scanned,
+            currentHidden: currentHidden
+        )
+        XCTAssertTrue(emptied.layout.hidden.isEmpty)
+        XCTAssertTrue(emptied.report.hiddenReplaced)
+        XCTAssertEqual(Set(emptied.layout.order), ["com.alpha", "com.bravo", "com.hidden"])
+    }
+
+    func testOmittedHiddenUnhidesClaimedID() throws {
+        let scanned = known(
+            ("com.chess", "Chess", "/C/Chess.app"),
+            ("com.preview", "Preview", "/P/Preview.app")
+        )
+        let result = try LaunchpadLayoutImporter.apply(
+            document: LaunchpadLayoutDocument(items: [.app(id: "com.chess")]),
+            mode: .merge,
+            strict: false,
+            scanned: scanned,
+            currentHidden: ["com.chess"]
+        )
+        XCTAssertEqual(result.layout.order.first, "com.chess")
+        XCTAssertEqual(result.report.unhiddenByClaim, ["com.chess"])
+        XCTAssertFalse(result.layout.hidden.contains("com.chess"))
+        XCTAssertTrue(result.report.appendedLeftover.contains("com.preview"))
+    }
+
+    func testCanonicalLayoutFixtureRoundTrip() throws {
+        let fixture = try fixtureData("canonical-layout")
+        let document = try LaunchpadLayoutDocument.makeDecoder()
+            .decode(LaunchpadLayoutDocument.self, from: fixture)
+        let encoded = try LaunchpadLayoutDocument.makeEncoder(pretty: true).encode(document)
+        XCTAssertEqual(
+            String(data: encoded, encoding: .utf8),
+            String(data: fixture, encoding: .utf8)
+        )
+
+        XCTAssertEqual(document.kind, LaunchpadLayoutKind.current)
+        XCTAssertEqual(document.schemaVersion, 1)
+        XCTAssertEqual(document.appVersion, "1.0.0")
+        XCTAssertEqual(document.hidden, ["com.apple.Chess"])
+        XCTAssertEqual(document.items, [
+            .app(id: "com.apple.Safari"),
+            .folder(
+                id: "folder-550e8400-e29b-41d4-a716-446655440000",
+                name: "开发",
+                apps: ["com.apple.dt.Xcode", "com.microsoft.VSCode"]
+            ),
+            .app(id: "com.apple.Preview")
+        ])
+    }
+
+    func testEncodeFoldersMatchesOnDiskFixtureAndDiffersFromLayoutEncoder() throws {
+        let fixture = try fixtureData("persist-folders")
+        let folders = try LaunchpadPersistence.decodeFolders(fixture)
+        let reencoded = try LaunchpadPersistence.encodeFolders(folders)
+        XCTAssertEqual(
+            String(data: reencoded, encoding: .utf8),
+            String(data: fixture, encoding: .utf8)
+        )
+
+        let layoutEncoded = try LaunchpadLayoutDocument.makeEncoder(pretty: true).encode(folders)
+        XCTAssertNotEqual(layoutEncoded, reencoded)
+        XCTAssertEqual(folders.map(\.id), ["folder-550e8400-e29b-41d4-a716-446655440000"])
+        XCTAssertEqual(folders.first?.appIDs, ["com.apple.dt.Xcode", "com.microsoft.VSCode"])
+    }
+
+    private func known(_ items: (String, String, String)...) -> [LaunchpadKnownApp] {
+        items
+            .map { LaunchpadKnownApp(id: $0.0, bundleIdentifier: $0.0, name: $0.1, path: $0.2) }
+            .sorted { lhs, rhs in
+                let nameOrder = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+                if nameOrder != .orderedSame {
+                    return nameOrder == .orderedAscending
+                }
+                return lhs.path < rhs.path
+            }
+    }
+
+    private func fixtureData(_ name: String) throws -> Data {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: name, withExtension: "json"))
+        return try Data(contentsOf: url)
+    }
+}


### PR DESCRIPTION
## Summary
Extract `QLaunchpadCore` with a versioned layout JSON model, hand-written `{type,id}` Codable, resolver, importer, and reconciler. Route `AppStore.reconcileLaunchpadItems()` through Core and persist folders/order/hidden only when they change.

## Test plan
- [ ] `swift test` (golden layout cases)
- [ ] `swift build`
- [ ] GUI no-arg launch still works (no CLI/Settings in this PR)