### PR TITLE
Apply layout documents in AppStore and reload via CFPreferences

### DIFF
--- a/Sources/QLaunchpad/AppDelegate.swift
+++ b/Sources/QLaunchpad/AppDelegate.swift
@@ -47,6 +47,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         buildLaunchpadPanel()
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(layoutDidChangeExternally(_:)),
+            name: .qlaunchpadLayoutDidChange,
+            object: nil
+        )
         store.load()
         installHotKey()
         applyDockIconPreference()
@@ -86,12 +92,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             self,
             selector: #selector(hotKeyRecordingChanged(_:)),
             name: .qlaunchpadHotKeyRecordingChanged,
-            object: nil
-        )
-        DistributedNotificationCenter.default().addObserver(
-            self,
-            selector: #selector(layoutDidChangeExternally(_:)),
-            name: .qlaunchpadLayoutDidChange,
             object: nil
         )
     }

--- a/Sources/QLaunchpad/AppDelegate.swift
+++ b/Sources/QLaunchpad/AppDelegate.swift
@@ -88,11 +88,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             name: .qlaunchpadHotKeyRecordingChanged,
             object: nil
         )
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(layoutDidChangeExternally(_:)),
+            name: .qlaunchpadLayoutDidChange,
+            object: nil
+        )
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         if let globalHotKeyMonitor { NSEvent.removeMonitor(globalHotKeyMonitor) }
         if let localHotKeyMonitor { NSEvent.removeMonitor(localHotKeyMonitor) }
+        DistributedNotificationCenter.default().removeObserver(
+            self,
+            name: .qlaunchpadLayoutDidChange,
+            object: nil
+        )
+    }
+
+    @objc private func layoutDidChangeExternally(_ note: Notification) {
+        let domain = note.object as? String
+        guard domain == Bundle.main.bundleIdentifier else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.store.reloadPersistedLayout()
+        }
     }
 
     /// A regular Dock application receives this callback when its Dock icon is

--- a/Sources/QLaunchpad/AppModel.swift
+++ b/Sources/QLaunchpad/AppModel.swift
@@ -486,6 +486,8 @@ final class AppStore: ObservableObject {
     private var lastScrollTime: CFTimeInterval = 0
     private var scanTask: Task<Void, Never>?
     private var layoutGeneration: UInt64 = 0
+    /// Bumped by import / external reload so Metal can drop an in-flight drag.
+    private(set) var dragGeneration: UInt64 = 0
 
     /// Points of scroll delta that equal one full page turn.
     private let pageScrollUnit: Double = 320
@@ -506,6 +508,7 @@ final class AppStore: ObservableObject {
         let defaults = UserDefaults.standard
         customApplicationSourcePaths = defaults.stringArray(forKey: LaunchpadPersistence.customSourcesKey) ?? []
         showHiddenAppsInSearch = defaults.bool(forKey: LaunchpadPersistence.showHiddenAppsKey)
+        rebuildLaunchpadItems()
     }
 
     deinit {
@@ -627,13 +630,19 @@ final class AppStore: ObservableObject {
     }
 
     func exportLayout(includeCatalog: Bool = true, includePaths: Bool = true) -> LaunchpadLayoutDocument {
-        let items: [LaunchpadLayoutItem] = launchpadItems.map { item in
-            switch item {
-            case .app(let app):
-                return .app(id: app.id)
-            case .folder(let folder):
-                return .folder(id: folder.id, name: folder.name, apps: folder.appIDs)
+        let folderByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
+        var seen = Set<String>()
+        var items: [LaunchpadLayoutItem] = []
+        for id in itemOrderIDs {
+            guard seen.insert(id).inserted else { continue }
+            if let folder = folderByID[id] {
+                items.append(.folder(id: folder.id, name: folder.name, apps: folder.appIDs))
+            } else {
+                items.append(.app(id: id))
             }
+        }
+        for folder in folders where seen.insert(folder.id).inserted {
+            items.append(.folder(id: folder.id, name: folder.name, apps: folder.appIDs))
         }
         let catalog: [LaunchpadLayoutCatalogEntry]? = includeCatalog
             ? apps.map { app in
@@ -665,6 +674,9 @@ final class AppStore: ObservableObject {
         _ document: LaunchpadLayoutDocument,
         mode: LaunchpadLayoutImportMode
     ) throws -> LaunchpadLayoutReport {
+        guard !isLoading, !apps.isEmpty else {
+            throw LaunchpadLayoutError.malformed("application catalog is empty")
+        }
         let (applied, report) = try LaunchpadLayoutImporter.apply(
             document: document,
             mode: mode,
@@ -702,7 +714,11 @@ final class AppStore: ObservableObject {
     func reloadPersistedLayout() {
         layoutGeneration += 1
         adoptPersistedLayout()
-        reconcileLaunchpadItems()
+        if apps.isEmpty {
+            rebuildLaunchpadItems()
+        } else {
+            reconcileLaunchpadItems(persist: false)
+        }
         cancelActiveDrag()
         if let openedFolderID, folder(withID: openedFolderID) == nil {
             exitFolder()
@@ -1400,9 +1416,10 @@ final class AppStore: ObservableObject {
     private func cancelActiveDrag() {
         isDraggingFolderApp = false
         isFolderRemovalTargeted = false
+        dragGeneration += 1
     }
 
-    private func reconcileLaunchpadItems() {
+    private func reconcileLaunchpadItems(persist: Bool = true) {
         let result = LaunchpadLayoutReconciler.reconcile(
             apps: knownApps(),
             folders: folders,
@@ -1411,7 +1428,9 @@ final class AppStore: ObservableObject {
         )
         folders = result.folders
         itemOrderIDs = result.order
-        persistLayout()
+        if persist {
+            persistLayout()
+        }
         rebuildLaunchpadItems()
     }
 
@@ -1425,6 +1444,9 @@ final class AppStore: ObservableObject {
     }
 
     private func persistLayout() {
+        // An empty catalog is the first-scan window, not a real layout. Persisting
+        // a reconcile of `apps = []` would write an empty grid over a live import.
+        guard !apps.isEmpty else { return }
         guard let foldersData = try? LaunchpadPreferenceStore.encodeFolders(folders) else { return }
         LaunchpadPreferenceStore.writeLayout(
             domain: Self.preferenceDomain,

--- a/Sources/QLaunchpad/AppModel.swift
+++ b/Sources/QLaunchpad/AppModel.swift
@@ -1,7 +1,10 @@
 import AppKit
 import Combine
 import Foundation
+import os
 import QLaunchpadCore
+
+private let layoutLogger = Logger(subsystem: "com.qzrzz.qlaunchpad", category: "layout")
 
 enum QLaunchpadPreferences {
     static let showMenuBarIconKey = "showMenuBarIcon"
@@ -482,22 +485,27 @@ final class AppStore: ObservableObject {
     private var scrollAccumulated: Double = 0
     private var lastScrollTime: CFTimeInterval = 0
     private var scanTask: Task<Void, Never>?
+    private var layoutGeneration: UInt64 = 0
 
     /// Points of scroll delta that equal one full page turn.
     private let pageScrollUnit: Double = 320
 
     private var itemOrderIDs: [String]
 
+    private static var preferenceDomain: String {
+        Bundle.main.bundleIdentifier ?? (kCFPreferencesCurrentApplication as String)
+    }
+
     init() {
+        let layout = LaunchpadPreferenceStore.readLayout(domain: Self.preferenceDomain)
+        LaunchpadPreferenceStore.writeThroughToStandardDefaults(layout)
+        hiddenAppIDs = Set(layout.hiddenIDs)
+        itemOrderIDs = layout.itemOrder
+        folders = (try? LaunchpadPreferenceStore.decodeFolders(layout.foldersData)) ?? []
+
         let defaults = UserDefaults.standard
-        hiddenAppIDs = Set(defaults.stringArray(forKey: LaunchpadPersistence.hiddenAppsKey) ?? [])
         customApplicationSourcePaths = defaults.stringArray(forKey: LaunchpadPersistence.customSourcesKey) ?? []
         showHiddenAppsInSearch = defaults.bool(forKey: LaunchpadPersistence.showHiddenAppsKey)
-        itemOrderIDs = defaults.stringArray(forKey: LaunchpadPersistence.itemOrderKey) ?? []
-        if let data = defaults.data(forKey: LaunchpadPersistence.foldersKey),
-           let savedFolders = try? LaunchpadPersistence.decodeFolders(data) {
-            folders = savedFolders
-        }
     }
 
     deinit {
@@ -590,10 +598,12 @@ final class AppStore: ObservableObject {
     func load() {
         // A detached scan cannot be stopped reliably once it has started.
         // Ignore duplicate requests instead of allowing two filesystem scans
-        // to run at the same time.
+        // to run at the same time. Import / external reload must not cancel
+        // or nil this task — they only bump `layoutGeneration`.
         guard scanTask == nil else { return }
 
         isLoading = true
+        let generationAtStart = layoutGeneration
         let additionalRoots = customApplicationSourcePaths.map { URL(fileURLWithPath: $0) }
         scanTask = Task { @MainActor [weak self] in
             let result = await Task.detached(priority: .userInitiated) {
@@ -601,6 +611,10 @@ final class AppStore: ObservableObject {
             }.value
             guard let self else { return }
             apps = result
+            if layoutGeneration != generationAtStart {
+                layoutLogger.debug("layout.scan.generationAdvanced readLayout=true")
+                adoptPersistedLayout()
+            }
             reconcileLaunchpadItems()
             // A scan also runs when the Launchpad is shown again. Keep the
             // current page while refreshing the catalog; the non-reset path
@@ -610,6 +624,92 @@ final class AppStore: ObservableObject {
             scanTask = nil
             NotificationCenter.default.post(name: .qlaunchpadStoreChanged, object: nil)
         }
+    }
+
+    func exportLayout(includeCatalog: Bool = true, includePaths: Bool = true) -> LaunchpadLayoutDocument {
+        let items: [LaunchpadLayoutItem] = launchpadItems.map { item in
+            switch item {
+            case .app(let app):
+                return .app(id: app.id)
+            case .folder(let folder):
+                return .folder(id: folder.id, name: folder.name, apps: folder.appIDs)
+            }
+        }
+        let catalog: [LaunchpadLayoutCatalogEntry]? = includeCatalog
+            ? apps.map { app in
+                LaunchpadLayoutCatalogEntry(
+                    id: app.id,
+                    bundleIdentifier: app.bundleIdentifier,
+                    name: app.name,
+                    path: includePaths ? app.url.standardizedFileURL.path : nil
+                )
+            }
+            : nil
+        let preset = GridLayoutPreset.current
+        return LaunchpadLayoutDocument(
+            exportedAt: Date(),
+            appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            grid: LaunchpadLayoutGrid(
+                preset: preset.rawValue,
+                columns: preset.columns,
+                rows: preset.rows,
+                pageCapacity: preset.columns * preset.rows
+            ),
+            items: items,
+            hidden: hiddenAppIDs.sorted(),
+            catalog: catalog
+        )
+    }
+
+    func applyLayout(
+        _ document: LaunchpadLayoutDocument,
+        mode: LaunchpadLayoutImportMode
+    ) throws -> LaunchpadLayoutReport {
+        let (applied, report) = try LaunchpadLayoutImporter.apply(
+            document: document,
+            mode: mode,
+            strict: false,
+            scanned: knownApps(),
+            currentHidden: hiddenAppIDs
+        )
+        writeLayoutBackupFailOpen()
+        let foldersData = try LaunchpadPreferenceStore.encodeFolders(applied.folders)
+        LaunchpadPreferenceStore.writeLayout(
+            domain: Self.preferenceDomain,
+            LaunchpadPersistedLayout(
+                itemOrder: applied.order,
+                foldersData: foldersData,
+                hiddenIDs: Array(applied.hidden)
+            )
+        )
+        folders = applied.folders
+        itemOrderIDs = applied.order
+        hiddenAppIDs = applied.hidden
+        rebuildLaunchpadItems()
+        cancelActiveDrag()
+        layoutGeneration += 1
+        if let openedFolderID, folder(withID: openedFolderID) == nil {
+            exitFolder()
+        }
+        refreshFilteredApps(resetPage: false)
+        layoutLogger.info(
+            "layout.import imported=\(report.importedRootItems) folders=\(report.importedFolders) skipped=\(report.skippedUnknown.count)"
+        )
+        NotificationCenter.default.post(name: .qlaunchpadStoreChanged, object: nil)
+        return report
+    }
+
+    func reloadPersistedLayout() {
+        layoutGeneration += 1
+        adoptPersistedLayout()
+        reconcileLaunchpadItems()
+        cancelActiveDrag()
+        if let openedFolderID, folder(withID: openedFolderID) == nil {
+            exitFolder()
+        }
+        refreshFilteredApps(resetPage: false)
+        layoutLogger.info("layout.reload from distributed notification")
+        NotificationCenter.default.post(name: .qlaunchpadStoreChanged, object: nil)
     }
 
     func updateSearch(_ text: String) {
@@ -1255,10 +1355,7 @@ final class AppStore: ObservableObject {
     }
 
     private func persistHiddenApps() {
-        let next = hiddenAppIDs.sorted()
-        let current = UserDefaults.standard.stringArray(forKey: LaunchpadPersistence.hiddenAppsKey) ?? []
-        guard next != current else { return }
-        UserDefaults.standard.set(next, forKey: LaunchpadPersistence.hiddenAppsKey)
+        persistLayout()
     }
 
     private func persistApplicationSources() {
@@ -1270,8 +1367,8 @@ final class AppStore: ObservableObject {
         return false
     }
 
-    private func reconcileLaunchpadItems() {
-        let known = apps.map {
+    private func knownApps() -> [LaunchpadKnownApp] {
+        apps.map {
             LaunchpadKnownApp(
                 id: $0.id,
                 bundleIdentifier: $0.bundleIdentifier,
@@ -1279,16 +1376,46 @@ final class AppStore: ObservableObject {
                 path: $0.url.standardizedFileURL.path
             )
         }
+    }
+
+    private func adoptPersistedLayout() {
+        let layout = LaunchpadPreferenceStore.readLayout(domain: Self.preferenceDomain)
+        LaunchpadPreferenceStore.writeThroughToStandardDefaults(layout)
+        itemOrderIDs = layout.itemOrder
+        hiddenAppIDs = Set(layout.hiddenIDs)
+        folders = (try? LaunchpadPreferenceStore.decodeFolders(layout.foldersData)) ?? []
+    }
+
+    private func writeLayoutBackupFailOpen() {
+        do {
+            try LaunchpadPreferenceStore.writeLayoutBackup(
+                domain: Self.preferenceDomain,
+                document: exportLayout(includeCatalog: true, includePaths: true)
+            )
+        } catch {
+            layoutLogger.warning("layout.backup.failed \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func cancelActiveDrag() {
+        isDraggingFolderApp = false
+        isFolderRemovalTargeted = false
+    }
+
+    private func reconcileLaunchpadItems() {
         let result = LaunchpadLayoutReconciler.reconcile(
-            apps: known,
+            apps: knownApps(),
             folders: folders,
             order: itemOrderIDs,
             hidden: hiddenAppIDs
         )
         folders = result.folders
         itemOrderIDs = result.order
-        persistFolders()
-        persistItemOrder()
+        persistLayout()
+        rebuildLaunchpadItems()
+    }
+
+    private func rebuildLaunchpadItems() {
         let folderByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
         launchpadItems = itemOrderIDs.compactMap { id in
             if let folder = folderByID[id] { return .folder(folder) }
@@ -1297,17 +1424,24 @@ final class AppStore: ObservableObject {
         }
     }
 
+    private func persistLayout() {
+        guard let foldersData = try? LaunchpadPreferenceStore.encodeFolders(folders) else { return }
+        LaunchpadPreferenceStore.writeLayout(
+            domain: Self.preferenceDomain,
+            LaunchpadPersistedLayout(
+                itemOrder: itemOrderIDs,
+                foldersData: foldersData,
+                hiddenIDs: hiddenAppIDs.sorted()
+            )
+        )
+    }
+
     private func persistFolders() {
-        guard let data = try? LaunchpadPersistence.encodeFolders(folders) else { return }
-        let current = UserDefaults.standard.data(forKey: LaunchpadPersistence.foldersKey)
-        guard data != current else { return }
-        UserDefaults.standard.set(data, forKey: LaunchpadPersistence.foldersKey)
+        persistLayout()
     }
 
     private func persistItemOrder() {
-        let current = UserDefaults.standard.stringArray(forKey: LaunchpadPersistence.itemOrderKey) ?? []
-        guard itemOrderIDs != current else { return }
-        UserDefaults.standard.set(itemOrderIDs, forKey: LaunchpadPersistence.itemOrderKey)
+        persistLayout()
     }
 
 }

--- a/Sources/QLaunchpad/LaunchpadUI.swift
+++ b/Sources/QLaunchpad/LaunchpadUI.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 extension Notification.Name {
     static let qlaunchpadStoreChanged = Notification.Name("QLaunchpadStoreChanged")
+    static let qlaunchpadLayoutDidChange = Notification.Name("com.qzrzz.qlaunchpad.layoutDidChange")
     static let qlaunchpadDismiss = Notification.Name("QLaunchpadDismiss")
     static let qlaunchpadPresentationChanged = Notification.Name("QLaunchpadPresentationChanged")
     static let qlaunchpadFocusSearch = Notification.Name("QLaunchpadFocusSearch")

--- a/Sources/QLaunchpad/MetalRenderer.swift
+++ b/Sources/QLaunchpad/MetalRenderer.swift
@@ -171,6 +171,7 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
 
     private var dragSource: Int?
     private var draggedAppID: String?
+    private var dragGeneration: UInt64 = 0
     private var dragDestination: Int?
     private var dragStart: CGPoint = .zero
     /// Current pointer position in top-left view coordinates.
@@ -798,6 +799,9 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
     }
 
     @objc private func storeChanged() {
+        if isDragCancelledByLayout {
+            discardCancelledDrag()
+        }
         resourcePrewarmSignature = nil
         scheduleResourcePrewarmingIfNeeded(prune: true)
         startDisplayLink()
@@ -2409,9 +2413,24 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
         contentTransitionPhase == .fadingOut ? frozenPageOffset : currentPageOffset
     }
 
+    private var isDragCancelledByLayout: Bool {
+        dragGeneration != store.dragGeneration
+    }
+
+    private func discardCancelledDrag() {
+        dragSource = nil
+        draggedAppID = nil
+        dragDestination = nil
+        dragHoverTargetID = nil
+        dragHoverVisualTargetID = nil
+        didDrag = false
+        store.setFolderDragState(isDragging: false)
+    }
+
     override func mouseDown(with event: NSEvent) {
         dragStart = convert(event.locationInWindow, from: nil)
         draggedAppID = nil
+        dragGeneration = store.dragGeneration
         dragPoint = CGPoint(x: dragStart.x, y: bounds.height - dragStart.y)
         dragGrabOffset = .zero
         edgePageDirection = 0
@@ -2680,6 +2699,10 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
     }
 
     override func mouseDragged(with event: NSEvent) {
+        if isDragCancelledByLayout {
+            discardCancelledDrag()
+            return
+        }
         let point = convert(event.locationInWindow, from: nil)
         dragPoint = CGPoint(x: point.x, y: bounds.height - point.y)
         if hypot(point.x - dragStart.x, point.y - dragStart.y) > 6 { didDrag = true }
@@ -2720,6 +2743,13 @@ final class LaunchpadMetalView: MTKView, MTKViewDelegate {
             isPanningPage = false
             store.setFolderDragState(isDragging: false)
             needsDisplay = true
+        }
+        if isDragCancelledByLayout {
+            if isPanningPage {
+                store.endPagePan()
+            }
+            discardCancelledDrag()
+            return
         }
         if isPanningPage {
             store.endPagePan()

--- a/Sources/QLaunchpadCore/LaunchpadPreferenceStore.swift
+++ b/Sources/QLaunchpadCore/LaunchpadPreferenceStore.swift
@@ -1,0 +1,170 @@
+import CoreFoundation
+import Foundation
+
+public struct LaunchpadPersistedLayout: Equatable, Sendable {
+    public var itemOrder: [String]
+    public var foldersData: Data
+    public var hiddenIDs: [String]
+
+    public init(itemOrder: [String], foldersData: Data, hiddenIDs: [String]) {
+        self.itemOrder = itemOrder
+        self.foldersData = foldersData
+        self.hiddenIDs = hiddenIDs
+    }
+}
+
+public enum LaunchpadPreferenceStore {
+    public static let releaseDomain = "com.qzrzz.qlaunchpad"
+    public static let developmentDomain = "com.qzrzz.qlaunchpad.dev"
+
+    public static func encodeFolders(_ folders: [AppFolder]) throws -> Data {
+        try LaunchpadPersistence.encodeFolders(folders)
+    }
+
+    public static func decodeFolders(_ data: Data) throws -> [AppFolder] {
+        try LaunchpadPersistence.decodeFolders(data)
+    }
+
+    /// Synchronizes the domain, then copies the three layout keys. Missing keys
+    /// are empty arrays / empty `Data`.
+    public static func readLayout(domain: String) -> LaunchpadPersistedLayout {
+        let applicationID = domain as CFString
+        CFPreferencesAppSynchronize(applicationID)
+        return LaunchpadPersistedLayout(
+            itemOrder: copyStringArray(key: LaunchpadPersistence.itemOrderKey, applicationID: applicationID),
+            foldersData: copyData(key: LaunchpadPersistence.foldersKey, applicationID: applicationID),
+            hiddenIDs: copyStringArray(key: LaunchpadPersistence.hiddenAppsKey, applicationID: applicationID)
+        )
+    }
+
+    /// Writes only keys that differ. Hidden is sorted before compare / set.
+    /// Folders must be `CFData` (encoded `[AppFolder]` bytes), not a JSON string.
+    public static func writeLayout(domain: String, _ layout: LaunchpadPersistedLayout) {
+        let applicationID = domain as CFString
+        let next = LaunchpadPersistedLayout(
+            itemOrder: layout.itemOrder,
+            foldersData: layout.foldersData,
+            hiddenIDs: layout.hiddenIDs.sorted()
+        )
+        let current = readLayout(domain: domain)
+        var changed = false
+
+        if next.itemOrder != current.itemOrder {
+            CFPreferencesSetAppValue(
+                LaunchpadPersistence.itemOrderKey as CFString,
+                next.itemOrder as CFArray,
+                applicationID
+            )
+            changed = true
+        }
+        if next.foldersData != current.foldersData {
+            CFPreferencesSetAppValue(
+                LaunchpadPersistence.foldersKey as CFString,
+                next.foldersData as CFData,
+                applicationID
+            )
+            changed = true
+        }
+        if next.hiddenIDs != current.hiddenIDs.sorted() {
+            CFPreferencesSetAppValue(
+                LaunchpadPersistence.hiddenAppsKey as CFString,
+                next.hiddenIDs as CFArray,
+                applicationID
+            )
+            changed = true
+        }
+        if changed {
+            CFPreferencesAppSynchronize(applicationID)
+        }
+        writeThroughIfCurrentDomain(domain, next)
+    }
+
+    public static func persistFolders(domain: String, _ folders: [AppFolder]) {
+        guard let foldersData = try? encodeFolders(folders) else { return }
+        var layout = readLayout(domain: domain)
+        layout.foldersData = foldersData
+        writeLayout(domain: domain, layout)
+    }
+
+    public static func persistItemOrder(domain: String, _ order: [String]) {
+        var layout = readLayout(domain: domain)
+        layout.itemOrder = order
+        writeLayout(domain: domain, layout)
+    }
+
+    public static func persistHiddenApps(domain: String, _ hidden: Set<String>) {
+        var layout = readLayout(domain: domain)
+        layout.hiddenIDs = hidden.sorted()
+        writeLayout(domain: domain, layout)
+    }
+
+    public static func readString(domain: String, key: String) -> String? {
+        let applicationID = domain as CFString
+        CFPreferencesAppSynchronize(applicationID)
+        guard let value = CFPreferencesCopyAppValue(key as CFString, applicationID) else {
+            return nil
+        }
+        return value as? String
+    }
+
+    public static func readStringArray(domain: String, key: String) -> [String] {
+        let applicationID = domain as CFString
+        CFPreferencesAppSynchronize(applicationID)
+        return copyStringArray(key: key, applicationID: applicationID)
+    }
+
+    public static func writeThroughToStandardDefaults(_ layout: LaunchpadPersistedLayout) {
+        let hidden = layout.hiddenIDs.sorted()
+        UserDefaults.standard.set(layout.itemOrder, forKey: LaunchpadPersistence.itemOrderKey)
+        UserDefaults.standard.set(layout.foldersData, forKey: LaunchpadPersistence.foldersKey)
+        UserDefaults.standard.set(hidden, forKey: LaunchpadPersistence.hiddenAppsKey)
+    }
+
+    public static func layoutBackupFileURL(domain: String) -> URL {
+        let folderName = domain == developmentDomain ? "QLaunch Dev" : "QLaunch"
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+            .appendingPathComponent(folderName, isDirectory: true)
+            .appendingPathComponent("layout.backup.json")
+    }
+
+    public static func writeLayoutBackup(domain: String, document: LaunchpadLayoutDocument) throws {
+        let data = try LaunchpadLayoutDocument.makeEncoder(pretty: true).encode(document)
+        let url = layoutBackupFileURL(domain: domain)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
+    }
+
+    private static func writeThroughIfCurrentDomain(_ domain: String, _ layout: LaunchpadPersistedLayout) {
+        let currentDomain = Bundle.main.bundleIdentifier
+            ?? (kCFPreferencesCurrentApplication as String)
+        guard domain == currentDomain else { return }
+        writeThroughToStandardDefaults(layout)
+    }
+
+    private static func copyStringArray(key: String, applicationID: CFString) -> [String] {
+        guard let value = CFPreferencesCopyAppValue(key as CFString, applicationID) else {
+            return []
+        }
+        if let strings = value as? [String] {
+            return strings
+        }
+        if let array = value as? NSArray {
+            return array.compactMap { $0 as? String }
+        }
+        return []
+    }
+
+    private static func copyData(key: String, applicationID: CFString) -> Data {
+        guard let value = CFPreferencesCopyAppValue(key as CFString, applicationID) else {
+            return Data()
+        }
+        if let data = value as? Data {
+            return data
+        }
+        return Data()
+    }
+}

--- a/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
@@ -1,0 +1,152 @@
+import CoreFoundation
+import XCTest
+@testable import QLaunchpadCore
+
+final class LaunchpadPreferenceStoreTests: XCTestCase {
+    private let domain = "com.qzrzz.qlaunchpad.tests.preference-store"
+
+    override func tearDown() {
+        clearLayoutDomain(domain)
+        super.tearDown()
+    }
+
+    func testWriteLayoutStoresCFArrayAndCFDataAndSortsHidden() throws {
+        let folders = [
+            AppFolder(
+                id: "folder-550e8400-e29b-41d4-a716-446655440000",
+                name: "开发",
+                appIDs: ["com.apple.dt.Xcode", "com.microsoft.VSCode"]
+            )
+        ]
+        let foldersData = try LaunchpadPreferenceStore.encodeFolders(folders)
+        LaunchpadPreferenceStore.writeLayout(
+            domain: domain,
+            LaunchpadPersistedLayout(
+                itemOrder: ["folder-550e8400-e29b-41d4-a716-446655440000", "com.apple.Safari"],
+                foldersData: foldersData,
+                hiddenIDs: ["com.zebra", "com.alpha"]
+            )
+        )
+
+        let read = LaunchpadPreferenceStore.readLayout(domain: domain)
+        XCTAssertEqual(
+            read.itemOrder,
+            ["folder-550e8400-e29b-41d4-a716-446655440000", "com.apple.Safari"]
+        )
+        XCTAssertEqual(read.foldersData, foldersData)
+        XCTAssertEqual(read.hiddenIDs, ["com.alpha", "com.zebra"])
+        XCTAssertEqual(try LaunchpadPreferenceStore.decodeFolders(read.foldersData), folders)
+
+        CFPreferencesAppSynchronize(domain as CFString)
+        let rawFolders = CFPreferencesCopyAppValue(
+            LaunchpadPersistence.foldersKey as CFString,
+            domain as CFString
+        )
+        XCTAssertTrue(rawFolders is Data)
+        XCTAssertFalse(rawFolders is String)
+
+        let rawOrder = CFPreferencesCopyAppValue(
+            LaunchpadPersistence.itemOrderKey as CFString,
+            domain as CFString
+        )
+        XCTAssertEqual(rawOrder as? [String], read.itemOrder)
+    }
+
+    func testPersistIfChangedLeavesIdenticalLayoutUntouched() throws {
+        let folders = [AppFolder(id: "folder-a", name: "A", appIDs: ["com.alpha"])]
+        let foldersData = try LaunchpadPreferenceStore.encodeFolders(folders)
+        let layout = LaunchpadPersistedLayout(
+            itemOrder: ["folder-a"],
+            foldersData: foldersData,
+            hiddenIDs: ["com.hidden"]
+        )
+        LaunchpadPreferenceStore.writeLayout(domain: domain, layout)
+        LaunchpadPreferenceStore.writeLayout(domain: domain, layout)
+
+        let read = LaunchpadPreferenceStore.readLayout(domain: domain)
+        XCTAssertEqual(read.itemOrder, ["folder-a"])
+        XCTAssertEqual(read.foldersData, foldersData)
+        XCTAssertEqual(read.hiddenIDs, ["com.hidden"])
+    }
+
+    func testReadStringAndStringArraySynchronizeFirst() {
+        CFPreferencesSetAppValue(
+            LaunchpadPersistence.gridLayoutPresetKey as CFString,
+            "7x5-128" as CFString,
+            domain as CFString
+        )
+        CFPreferencesSetAppValue(
+            LaunchpadPersistence.customSourcesKey as CFString,
+            ["/tmp/Extra Apps"] as CFArray,
+            domain as CFString
+        )
+        CFPreferencesAppSynchronize(domain as CFString)
+
+        XCTAssertEqual(
+            LaunchpadPreferenceStore.readString(
+                domain: domain,
+                key: LaunchpadPersistence.gridLayoutPresetKey
+            ),
+            "7x5-128"
+        )
+        XCTAssertEqual(
+            LaunchpadPreferenceStore.readStringArray(
+                domain: domain,
+                key: LaunchpadPersistence.customSourcesKey
+            ),
+            ["/tmp/Extra Apps"]
+        )
+    }
+
+    func testMissingLayoutKeysAreEmpty() {
+        let read = LaunchpadPreferenceStore.readLayout(domain: domain)
+        XCTAssertEqual(read.itemOrder, [])
+        XCTAssertEqual(read.foldersData, Data())
+        XCTAssertEqual(read.hiddenIDs, [])
+        XCTAssertNil(
+            LaunchpadPreferenceStore.readString(
+                domain: domain,
+                key: LaunchpadPersistence.gridLayoutPresetKey
+            )
+        )
+        XCTAssertEqual(
+            LaunchpadPreferenceStore.readStringArray(
+                domain: domain,
+                key: LaunchpadPersistence.customSourcesKey
+            ),
+            []
+        )
+    }
+
+    func testBackupURLSplitsReleaseAndDevDomains() {
+        let release = LaunchpadPreferenceStore.layoutBackupFileURL(
+            domain: LaunchpadPreferenceStore.releaseDomain
+        )
+        let development = LaunchpadPreferenceStore.layoutBackupFileURL(
+            domain: LaunchpadPreferenceStore.developmentDomain
+        )
+        XCTAssertTrue(release.path.hasSuffix("Application Support/QLaunch/layout.backup.json"))
+        XCTAssertTrue(development.path.hasSuffix("Application Support/QLaunch Dev/layout.backup.json"))
+        XCTAssertNotEqual(release, development)
+    }
+
+    func testEncodeFoldersWrapperMatchesPersistenceEncoder() throws {
+        let folders = [
+            AppFolder(id: "folder-1", name: "开发", appIDs: ["com.example.Foo#/Users/alex/Applications/Foo.app"])
+        ]
+        XCTAssertEqual(
+            try LaunchpadPreferenceStore.encodeFolders(folders),
+            try LaunchpadPersistence.encodeFolders(folders)
+        )
+    }
+
+    private func clearLayoutDomain(_ domain: String) {
+        let applicationID = domain as CFString
+        CFPreferencesSetAppValue(LaunchpadPersistence.itemOrderKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.foldersKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.hiddenAppsKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.gridLayoutPresetKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue(LaunchpadPersistence.customSourcesKey as CFString, nil, applicationID)
+        CFPreferencesAppSynchronize(applicationID)
+    }
+}

--- a/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
+++ b/Tests/QLaunchpadCoreTests/LaunchpadPreferenceStoreTests.swift
@@ -52,7 +52,7 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
         XCTAssertEqual(rawOrder as? [String], read.itemOrder)
     }
 
-    func testPersistIfChangedLeavesIdenticalLayoutUntouched() throws {
+    func testPersistIfChangedSkipsSecondWrite() throws {
         let folders = [AppFolder(id: "folder-a", name: "A", appIDs: ["com.alpha"])]
         let foldersData = try LaunchpadPreferenceStore.encodeFolders(folders)
         let layout = LaunchpadPersistedLayout(
@@ -61,7 +61,26 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
             hiddenIDs: ["com.hidden"]
         )
         LaunchpadPreferenceStore.writeLayout(domain: domain, layout)
+
+        let probeKey = "layoutWriteProbe"
+        CFPreferencesSetAppValue(probeKey as CFString, "keep" as CFString, domain as CFString)
+        CFPreferencesAppSynchronize(domain as CFString)
+
+        let plistURL = preferencesPlistURL(domain)
+        let firstModified = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: plistURL.path)[.modificationDate] as? Date
+        )
+
         LaunchpadPreferenceStore.writeLayout(domain: domain, layout)
+
+        let secondModified = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: plistURL.path)[.modificationDate] as? Date
+        )
+        XCTAssertEqual(firstModified, secondModified)
+        XCTAssertEqual(
+            CFPreferencesCopyAppValue(probeKey as CFString, domain as CFString) as? String,
+            "keep"
+        )
 
         let read = LaunchpadPreferenceStore.readLayout(domain: domain)
         XCTAssertEqual(read.itemOrder, ["folder-a"])
@@ -69,7 +88,7 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
         XCTAssertEqual(read.hiddenIDs, ["com.hidden"])
     }
 
-    func testReadStringAndStringArraySynchronizeFirst() {
+    func testReadStringAndStringArray() {
         CFPreferencesSetAppValue(
             LaunchpadPersistence.gridLayoutPresetKey as CFString,
             "7x5-128" as CFString,
@@ -140,6 +159,11 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
         )
     }
 
+    private func preferencesPlistURL(_ domain: String) -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Preferences/\(domain).plist")
+    }
+
     private func clearLayoutDomain(_ domain: String) {
         let applicationID = domain as CFString
         CFPreferencesSetAppValue(LaunchpadPersistence.itemOrderKey as CFString, nil, applicationID)
@@ -147,6 +171,8 @@ final class LaunchpadPreferenceStoreTests: XCTestCase {
         CFPreferencesSetAppValue(LaunchpadPersistence.hiddenAppsKey as CFString, nil, applicationID)
         CFPreferencesSetAppValue(LaunchpadPersistence.gridLayoutPresetKey as CFString, nil, applicationID)
         CFPreferencesSetAppValue(LaunchpadPersistence.customSourcesKey as CFString, nil, applicationID)
+        CFPreferencesSetAppValue("layoutWriteProbe" as CFString, nil, applicationID)
         CFPreferencesAppSynchronize(applicationID)
+        try? FileManager.default.removeItem(at: preferencesPlistURL(domain))
     }
 }


### PR DESCRIPTION
## Summary
Add `LaunchpadPreferenceStore`, `AppStore.exportLayout` / `applyLayout` / `reloadPersistedLayout`, a `layoutGeneration` fence so scans cannot resurrect a pre-import order, DNC observer, and fail-open Application Support backup.

## Test plan
- [ ] `swift test`
- [ ] In-process apply redraws the grid
- [ ] External write + DNC reloads without restart; a later show does not restore the old order